### PR TITLE
Melhorias ansible

### DIFF
--- a/ansible/01-pki/tasks/01-setup.yml
+++ b/ansible/01-pki/tasks/01-setup.yml
@@ -2,19 +2,14 @@
 ---
 - name: Remover estrutura anterior de outras gerações no caso de regerar os certificados
   ansible.builtin.file:
-    path: "{{ item }}"
+    path: "{{ pki_pasta_base }}"
     state: absent
   when: pki_regerar_certs | bool
-  loop:
-    - "{{ pki_pasta_base }}"
 
 - name: Criar estrutura de diretórios para certificados
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     mode: "0755"
-  loop:
-    - "{{ pki_pasta_base }}"
-    - "{{ pki_pasta_base }}/root"
-    - "{{ pki_pasta_base }}/kubernetes"
-    - "{{ pki_pasta_base }}/etcd"
+    recurse: true
+  loop: "{{ pki_pastas.values() | list }}"

--- a/ansible/01-pki/tasks/02-root-ca.yml
+++ b/ansible/01-pki/tasks/02-root-ca.yml
@@ -25,10 +25,8 @@
     privatekey_path: "{{ pki_root_ca.path_chave }}"
     digest: "{{ pki_algoritmo_hash }}"
     mode: 0600
-    CN: "{{ pki_root_ca.common_name }}"
-    OU:
-      - "{{ pki_root_ca.organizacao }}"
-      - "Autoridade Certificadora Kubernetes in a Box"
+    subject: "{{ pki_root_ca.subject }}"
+    use_common_name_for_san: false
     basic_constraints:
       - "CA:TRUE"
     basic_constraints_critical: true

--- a/ansible/01-pki/tasks/02-root-ca.yml
+++ b/ansible/01-pki/tasks/02-root-ca.yml
@@ -30,9 +30,7 @@
     basic_constraints:
       - "CA:TRUE"
     basic_constraints_critical: true
-    key_usage:
-      - keyCertSign
-      - cRLSign
+    key_usage: "{{ pki_root_ca.key_usage }}"
     key_usage_critical: true
     force: true
   when: not ca_root_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)

--- a/ansible/01-pki/tasks/03-cas-intermediarios.yml
+++ b/ansible/01-pki/tasks/03-cas-intermediarios.yml
@@ -53,45 +53,4 @@
     force: true
   when: not ca_intermediario_arquivos.results[2].stat.exists or (pki_regerar_certs | default(false) | bool)
   delegate_to: localhost
-
-# - name: Criar chave privada do Root CA
-#   community.crypto.openssl_privatekey:
-#     path: "{{ pki_root_ca.path_chave }}"
-#     type: "{{ pki_cifra_tipo }}"
-#     curve: "{{ pki_cifra_algo }}"
-#     state: "present"
-#     force: true
-#   when: not ca_root_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
-#   delegate_to: localhost
-
-# - name: Gerar CSR do Root CA
-#   community.crypto.openssl_csr:
-#     path: "{{ pki_root_ca.path_csr }}"
-#     privatekey_path: "{{ pki_root_ca.path_chave }}"
-#     digest: "{{ pki_algoritmo_hash }}"
-#     mode: 0600
-#     subject: "{{ pki_root_ca.subject }}"
-#     use_common_name_for_san: false
-#     basic_constraints:
-#       - "CA:TRUE"
-#     basic_constraints_critical: true
-#     key_usage:
-#       - keyCertSign
-#       - cRLSign
-#     key_usage_critical: true
-#     force: true
-#   when: not ca_root_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
-#   delegate_to: localhost
-
-# - name: Criar certificado auto-assinado do Root CA
-#   community.crypto.x509_certificate:
-#     path: "{{ pki_root_ca.path_cert }}"
-#     csr_path: "{{ pki_root_ca.path_csr }}"
-#     privatekey_path: "{{ pki_root_ca.path_chave }}"
-#     provider: selfsigned
-#     selfsigned_digest: "{{ pki_algoritmo_hash }}"
-#     selfsigned_not_after: "+{{ pki_validade.root }}d"
-#     mode: "0644"
-#     force: true
-#   when: not ca_root_arquivos.results[2].stat.exists or (pki_regerar_certs | default(false) | bool)
-#   delegate_to: localhost
+  

--- a/ansible/01-pki/tasks/03-cas-intermediarios.yml
+++ b/ansible/01-pki/tasks/03-cas-intermediarios.yml
@@ -1,2 +1,97 @@
 # ansible/01-pki/tasks/03-cas-intermediarios.yml
 ---
+- name: Verificar arquivos existentes da CA intermediária ({{ item.nome }})
+  ansible.builtin.stat:
+    path: "{{ arquivo }}"
+  loop:
+    - "{{ item.path_chave }}"
+    - "{{ item.path_csr }}"
+    - "{{ item.path_cert }}"
+  loop_control:
+    loop_var: arquivo
+    label: "{{ arquivo }}"
+  register: ca_intermediario_arquivos
+  delegate_to: localhost
+
+- name: Criar chave privada da CA intermediária ({{ item.nome }})
+  community.crypto.openssl_privatekey:
+    path: "{{ item.path_chave }}"
+    type: "{{ pki_cifra_tipo }}"
+    curve: "{{ pki_cifra_algo }}"
+    state: "present"
+    force: true
+  when: not ca_intermediario_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  delegate_to: localhost
+
+- name: Gerar CSR da CA intermediária ({{ item.nome }})
+  community.crypto.openssl_csr:
+    path: "{{ item.path_csr }}"
+    privatekey_path: "{{ item.path_chave }}"
+    digest: "{{ pki_algoritmo_hash }}"
+    mode: "0600"
+    subject: "{{ item.subject }}"
+    use_common_name_for_san: false
+    basic_constraints:
+      - "CA:TRUE"
+    basic_constraints_critical: true
+    key_usage: "{{ item.key_usage }}"
+    key_usage_critical: true
+    force: true
+  when: not ca_intermediario_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  delegate_to: localhost
+
+- name: Assinar certificado da CA intermediária ({{ item.nome }}) com o Root CA
+  community.crypto.x509_certificate:
+    path: "{{ item.path_cert }}"
+    csr_path: "{{ item.path_csr }}"
+    provider: ownca
+    ownca_path: "{{ pki_root_ca.path_cert }}"
+    ownca_privatekey_path: "{{ pki_root_ca.path_chave }}"
+    ownca_digest: "{{ pki_algoritmo_hash }}"
+    ownca_not_after: "+{{ pki_validade.intermediario }}d"
+    mode: "0644"
+    force: true
+  when: not ca_intermediario_arquivos.results[2].stat.exists or (pki_regerar_certs | default(false) | bool)
+  delegate_to: localhost
+
+# - name: Criar chave privada do Root CA
+#   community.crypto.openssl_privatekey:
+#     path: "{{ pki_root_ca.path_chave }}"
+#     type: "{{ pki_cifra_tipo }}"
+#     curve: "{{ pki_cifra_algo }}"
+#     state: "present"
+#     force: true
+#   when: not ca_root_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+#   delegate_to: localhost
+
+# - name: Gerar CSR do Root CA
+#   community.crypto.openssl_csr:
+#     path: "{{ pki_root_ca.path_csr }}"
+#     privatekey_path: "{{ pki_root_ca.path_chave }}"
+#     digest: "{{ pki_algoritmo_hash }}"
+#     mode: 0600
+#     subject: "{{ pki_root_ca.subject }}"
+#     use_common_name_for_san: false
+#     basic_constraints:
+#       - "CA:TRUE"
+#     basic_constraints_critical: true
+#     key_usage:
+#       - keyCertSign
+#       - cRLSign
+#     key_usage_critical: true
+#     force: true
+#   when: not ca_root_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+#   delegate_to: localhost
+
+# - name: Criar certificado auto-assinado do Root CA
+#   community.crypto.x509_certificate:
+#     path: "{{ pki_root_ca.path_cert }}"
+#     csr_path: "{{ pki_root_ca.path_csr }}"
+#     privatekey_path: "{{ pki_root_ca.path_chave }}"
+#     provider: selfsigned
+#     selfsigned_digest: "{{ pki_algoritmo_hash }}"
+#     selfsigned_not_after: "+{{ pki_validade.root }}d"
+#     mode: "0644"
+#     force: true
+#   when: not ca_root_arquivos.results[2].stat.exists or (pki_regerar_certs | default(false) | bool)
+#   delegate_to: localhost

--- a/ansible/01-pki/tasks/main.yml
+++ b/ansible/01-pki/tasks/main.yml
@@ -12,3 +12,13 @@
     - pki:ca
     - pki:root
     - pki:root:ca
+
+- ansible.builtin.include_tasks: 03-cas-intermediarios.yml
+  loop: "{{ pki_cas_intermediarios }}"
+  loop_control:
+    label: "{{ item.nome }}"
+  tags:
+    - pki
+    - pki:ca
+    - pki:intermediarios
+    - pki:ca:intermediarios

--- a/inventario/group_vars/all.yml
+++ b/inventario/group_vars/all.yml
@@ -37,12 +37,20 @@ pki_pasta_base: "{{ pasta_artefatos }}/pki"
 # Configuração que decide se os certificados serão regerados
 pki_regerar_certs: true
 
-# Configurações padrão para o Root CA
+# Configurações padrão para todos os certificados
+pki_subject_padrao: &pki_subject_padrao
+  C: BR
+  ST: Minas Gerais
+  L: Uberlândia
+  O: K8s-in-a-Box
+
+# Configurações para o Root CA
 pki_root_ca:
-  nome: root
-  common_name: "root-ca"
-  organizacao: "K8s-in-a-Box Root CA"
   path_chave: "{{ pki_pasta_base }}/root/ca-root-chave.pem"
   path_csr: "{{ pki_pasta_base }}/root/ca-root.csr"
   path_cert: "{{ pki_pasta_base }}/root/ca-root-cert.pem"
   validade: "{{ pki_validade.root | default(1825) }}"
+  subject:
+    <<: *pki_subject_padrao
+    OU: Autoridade Raiz
+    CN: K8s-in-a-Box Root CA

--- a/inventario/group_vars/all.yml
+++ b/inventario/group_vars/all.yml
@@ -34,6 +34,12 @@ porta_kubeapiserver: 6443
 # Pasta onde ficam os artefatos dos certificados
 pki_pasta_base: "{{ pasta_artefatos }}/pki"
 
+# Pastas para os CAs e certificados:
+pki_pastas:
+  ca: "{{ pki_pasta_base }}/CAs"
+  etcd: "{{ pki_pasta_base }}/etcd"
+  k8s: "{{ pki_pasta_base }}/k8s"
+
 # Configuração que decide se os certificados serão regerados
 pki_regerar_certs: true
 
@@ -46,11 +52,44 @@ pki_subject_padrao: &pki_subject_padrao
 
 # Configurações para o Root CA
 pki_root_ca:
-  path_chave: "{{ pki_pasta_base }}/root/ca-root-chave.pem"
-  path_csr: "{{ pki_pasta_base }}/root/ca-root.csr"
-  path_cert: "{{ pki_pasta_base }}/root/ca-root-cert.pem"
+  path_chave: "{{ pki_pastas.ca }}/ca-root-chave.pem"
+  path_csr: "{{ pki_pastas.ca }}/ca-root.csr"
+  path_cert: "{{ pki_pastas.ca }}/ca-root-cert.pem"
   validade: "{{ pki_validade.root | default(1825) }}"
   subject:
     <<: *pki_subject_padrao
     OU: Autoridade Raiz
     CN: K8s-in-a-Box Root CA
+  key_usage:
+    - keyCertSign
+    - cRLSign
+
+# Configurações para os CAs intermediários
+pki_cas_intermediarios:
+  - nome: etcd
+    path_chave: "{{ pki_pastas.ca }}/ca-etcd-chave.pem"
+    path_csr: "{{ pki_pastas.ca }}/ca-etcd.csr"
+    path_cert: "{{ pki_pastas.ca }}/ca-etcd-cert.pem"
+    validade: "{{ pki_validade.intermediario | default(365) }}"
+    subject:
+      <<: *pki_subject_padrao
+      OU: Autoridade Intermediária Etcd
+      CN: K8s-in-a-Box Etcd CA
+    key_usage:
+      - digitalSignature
+      - keyCertSign
+      - cRLSign
+  
+  - nome: kubernetes
+    path_chave: "{{ pki_pastas.ca }}/ca-k8s-chave.pem"
+    path_csr: "{{ pki_pastas.ca }}/ca-k8s.csr"
+    path_cert: "{{ pki_pastas.ca }}/ca-k8s-cert.pem"
+    validade: "{{ pki_validade.intermediario | default(365) }}"
+    subject:
+      <<: *pki_subject_padrao
+      OU: Autoridade Intermediária Kubernetes
+      CN: K8s-in-a-Box Kubernetes CA
+    key_usage:
+      - digitalSignature
+      - keyCertSign
+      - cRLSign


### PR DESCRIPTION
Implementada a tasklist para criação das cadeias de CAs intermediários (etcd e Kubernetes), mantendo o mesmo padrão do Root CA.

Foram incluídas novas variáveis no `group_all` para centralizar configurações, ajustada a estrutura de pastas para uso parametrizado e padronizado o uso de variáveis também na tasklist do Root CA.
