### PR TITLE
Scripts kubectl helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,12 @@ help: ## Mostra esta ajuda
 	grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \
 	awk 'BEGIN {FS = ":.*?## "}; {printf "  make %-22s %s\n", $$1, $$2}'
 
-up: ## Sobe as VMs e recria a pasta artefatos/
+up-cluster: ## Sobe as VMs e recria a pasta artefatos/
 	mkdir -p $(ARTEFATOS)
 	vagrant up
+
+up-ops: ## Sobe a vm kubox
+	vagrant up kubox
 
 down: ## Interrompe as VMs
 	vagrant halt
@@ -85,13 +88,12 @@ kube-proxy: ## Executa apenas a role kube-proxy (use com um snapshot de kubelet)
 	@echo "Executando role kube-proxy..."
 	ANSIBLE_CONFIG="$(CFG)" ansible-playbook "./ansible/cluster.yml" $(ANSIBLE_VERBOSE) --tags kube-proxy
 
-cluster: up ## Executa toda a construção do cluster kubernetes
+cluster: up-cluster ## Executa toda a construção do cluster kubernetes
 	@echo "Executando todas as roles de cluster..."
 	ANSIBLE_CONFIG="$(CFG)" ansible-playbook "./ansible/cluster.yml" $(ANSIBLE_VERBOSE) --tags cluster
 
-ops: ## Executa toda a construção do cliente kubox para operação do cluster
+ops: up-ops ## Executa toda a construção do cliente kubox para operação do cluster
 	@echo "Executando todas as roles de operações..."
-	vagrant up kubox
 	ANSIBLE_CONFIG="$(CFG)" ansible-playbook "./ansible/ops.yml" $(ANSIBLE_VERBOSE) --tags ops
 
 ferramentas-ops: ## Executa apenas a role ferramentas-ops
@@ -105,7 +107,7 @@ configuracoes-ops: ## Executa apenas a role configuracoes-ops
 k8s-in-a-box: cluster ops ## Executa todo o projeto
 
 # Tasks com encadeamento de execução
-cadeia-artefatos: up artefatos ## Executa todas as dependências para a role artefatos
+cadeia-artefatos: up-cluster artefatos ## Executa todas as dependências para a role artefatos
 
 cadeia-pki: cadeia-artefatos pki ## Executa todas as dependências para a role pki
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,9 +23,10 @@ grupos.each do |grupo, dados|
 
   dados["hosts"].each do |nome, props|
     nodes[nome] = {
-      "ip"     => props["ansible_host"],
-      "memory" => props["memory"],
-      "cpus"   => props["cpus"]
+      "ip"        => props["ansible_host"],
+      "memory"    => props["memory"],
+      "cpus"      => props["cpus"],
+      "autostart" => props.fetch("autostart", true)
     }
   end
 end
@@ -82,7 +83,7 @@ Vagrant.configure("2") do |config|
   end
 
   nodes.each do |nome_no, specs|
-    config.vm.define nome_no do |node|
+    config.vm.define nome_no, autostart: specs["autostart"] do |node|
       node.vm.hostname = nome_no
       node.vm.network "private_network", ip: specs["ip"],
         libvirt__network_name: "#{PROJETO}_mgmt",

--- a/ansible/02-sistema/defaults/main.yml
+++ b/ansible/02-sistema/defaults/main.yml
@@ -1,7 +1,7 @@
 # ansible/02-sistema/defaults/main.yml
 ---
 # Variável para controlar a atualização dos pacotes do sistema instalado (all, patch, none)
-atualiza_sistema: "none"
+atualiza_sistema: "seguranca"
 
 locale_lang: "pt_BR.UTF-8"
 timezone_tz: "America/Sao_Paulo"

--- a/ansible/02-sistema/tasks/1-base.yml
+++ b/ansible/02-sistema/tasks/1-base.yml
@@ -30,7 +30,7 @@
   ansible.builtin.dnf:
     name: "*"
     state: latest
-  when: atualiza_sistema == "all"
+  when: atualiza_sistema == "todos"
 
 - name: Atualizar apenas pacotes de segurança  # noqa package-latest
   become: true
@@ -38,7 +38,7 @@
     name: "*"
     security: true
     state: latest
-  when: atualiza_sistema == "patch"
+  when: atualiza_sistema == "seguranca"
 
 - name: Instalar pacotes extras necessários
   become: true

--- a/ansible/11-ferramentas-cluster/tasks/01-instalacao.yml
+++ b/ansible/11-ferramentas-cluster/tasks/01-instalacao.yml
@@ -23,13 +23,13 @@
     - name: Descompactar etcdctl
       ansible.builtin.unarchive:
         src: "/tmp/etcd-bin.tar.gz"
-        dest: "/tmp/etcd"
+        dest: "/tmp/etcdctl"
         remote_src: true
         mode: "0755"
 
     - name: Instalar binário do etcdctl em /usr/local/bin
       ansible.builtin.copy:
-        src: "/tmp/etcd/etcd-{{ versao_etcd }}-linux-amd64/{{ item }}"
+        src: "/tmp/etcdctl/etcd-{{ versao_etcd }}-linux-amd64/{{ item }}"
         dest: "/usr/local/bin/{{ item }}"
         mode: "0755"
         remote_src: true
@@ -40,7 +40,7 @@
   always:
     - name: Remover diretório temporário do etcdctl
       ansible.builtin.file:
-        path: "/tmp/etcd"
+        path: "/tmp/etcdctl"
         state: absent
 
     - name: Remover arquivo temporário do etcdctl

--- a/ansible/12-configuracoes-cluster/tasks/01-labels-taints.yml
+++ b/ansible/12-configuracoes-cluster/tasks/01-labels-taints.yml
@@ -1,14 +1,24 @@
 # ansible/12-configuracoes-cluster/tasks/01-labels-taints.yml
 ---
-- name: Aplicar taint NoSchedule nos managers
+- name: Verificar taints atuais dos managers
   ansible.builtin.command:
-    cmd: "kubectl taint node {{ manager_host }} node-role.kubernetes.io/control-plane=:NoSchedule"
+    cmd: "kubectl get node {{ manager_host }} -o jsonpath='{.spec.taints}'"
   loop: "{{ groups['managers'] }}"
   loop_control:
     loop_var: manager_host
-  register: resultado_taint_managers
-  changed_when: "'node/' ~ manager_host ~ ' modified' in resultado_taint_managers.stdout"
-  failed_when: false
+  register: taints_atuais
+  changed_when: false
+
+- name: Aplicar taint NoSchedule nos managers
+  ansible.builtin.command:
+    cmd: "kubectl taint node {{ item.manager_host }} node-role.kubernetes.io/control-plane=:NoSchedule"
+  loop: "{{ taints_atuais.results }}"
+  loop_control:
+    loop_var: item
+    label: "{{ item.manager_host }}"
+  when: "'NoSchedule' not in item.stdout"
+  register: resultado_taint
+  changed_when: "'node/' ~ item.manager_host ~ ' tainted' in resultado_taint.stdout"
 
 - name: Aplicar label control-plane nos managers
   ansible.builtin.command:

--- a/ansible/12-configuracoes-cluster/tasks/02-flannel.yml
+++ b/ansible/12-configuracoes-cluster/tasks/02-flannel.yml
@@ -1,14 +1,14 @@
 # ansible/12-configuracoes-cluster/tasks/02-flannel.yml
 ---
-- name: Verificar se namespace kube-flannel já existe
+- name: Verificar releases instaladas no Helm
   ansible.builtin.command:
-    cmd: "kubectl get ns kube-flannel"
-  register: resultado_ns
+    cmd: "helm list -Aq"
+  register: helm_releases
   failed_when: false
   changed_when: false
 
 - name: Instalar o Flannel se não estiver instalado
-  when: resultado_ns.rc != 0
+  when: not (helm_releases.stdout | regex_search('^flannel$', multiline=True))
   block:
     - name: Garantir que namespace kube-flannel existe
       ansible.builtin.command:
@@ -30,10 +30,22 @@
         cmd: "helm repo update"
       changed_when: false
 
+    - name: Garantir diretório charts/ na home do usuário do ansible
+      ansible.builtin.file:
+        path: "/home/{{ ansible_user }}/charts"
+        state: directory
+        mode: "0755"
+
+    - name: Criar arquivo de configuração Helm para o Flannel
+      ansible.builtin.template:
+        src: flannel-helm-config.yml.j2
+        dest: "/home/{{ ansible_user }}/charts/flannel-helm-config.yml"
+        mode: "0644"
+
     - name: Instalar chart do Flannel
       ansible.builtin.command:
         cmd: >
           helm install flannel flannel/flannel
           --namespace kube-flannel
-          --set podCidr="{{ rede_cidr_pods }}"
+          --values /home/{{ ansible_user }}/charts/flannel-helm-config.yml
       changed_when: true

--- a/ansible/12-configuracoes-cluster/tasks/03-coredns.yml
+++ b/ansible/12-configuracoes-cluster/tasks/03-coredns.yml
@@ -1,0 +1,41 @@
+# ansible/12-configuracoes-cluster/tasks/03-coredns.yml
+---
+- name: Verificar releases instaladas no Helm
+  ansible.builtin.command:
+    cmd: "helm list -Aq"
+  register: helm_releases
+  failed_when: false
+  changed_when: false
+
+- name: Instalar o CoreDNS se não estiver instalado
+  when: not (helm_releases.stdout | regex_search('^coredns$', multiline=True))
+  block:
+    - name: Adicionar repositório helm coredns
+      ansible.builtin.command:
+        cmd: "helm repo add coredns https://coredns.github.io/helm"
+      changed_when: true
+
+    - name: Atualizar repositórios helm
+      ansible.builtin.command:
+        cmd: "helm repo update"
+      changed_when: false
+
+    - name: Garantir diretório charts/ na home do usuário do ansible
+      ansible.builtin.file:
+        path: "/home/{{ ansible_user }}/charts"
+        state: directory
+        mode: "0755"
+
+    - name: Criar arquivo de configuração Helm para o CoreDNS
+      ansible.builtin.template:
+        src: coredns-helm-config.yml.j2
+        dest: "/home/{{ ansible_user }}/charts/coredns-helm-config.yml"
+        mode: "0644"
+
+    - name: Instalar chart do CoreDNS
+      ansible.builtin.command:
+        cmd: >
+          helm install coredns coredns/coredns
+          --namespace kube-system
+          --values /home/{{ ansible_user }}/charts/coredns-helm-config.yml
+      changed_when: true

--- a/ansible/12-configuracoes-cluster/tasks/main.yml
+++ b/ansible/12-configuracoes-cluster/tasks/main.yml
@@ -3,5 +3,8 @@
 - name: Configurar Labels e Taints dos nós do cluster
   ansible.builtin.import_tasks: 01-labels-taints.yml
 
-- name: Configuração do Flannel
+- name: Instalação e configuração do Flannel
   ansible.builtin.import_tasks: 02-flannel.yml
+
+- name: Instalação e configuração do CoreDNS
+  ansible.builtin.import_tasks: 03-coredns.yml

--- a/ansible/12-configuracoes-cluster/templates/coredns-helm-config.yml.j2
+++ b/ansible/12-configuracoes-cluster/templates/coredns-helm-config.yml.j2
@@ -1,0 +1,31 @@
+# Serviço que expõe o CoreDNS dentro do cluster
+service:
+  name: kube-dns
+  type: ClusterIP
+  # IP fixo para o serviço
+  clusterIP: {{ coredns_ip }}
+
+# Número de réplicas do CoreDNS
+replicaCount: 2
+
+# Recursos mínimos para estabilidade
+resources:
+  requests:
+    cpu: 100m
+    memory: 70Mi
+  limits:
+    cpu: 500m
+    memory: 170Mi
+
+# Anti-affinity para garantir que os pods de CoreDNS
+# não sejam agendados no mesmo nó
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: k8s-app
+              operator: In
+              values:
+                - kube-dns
+        topologyKey: "kubernetes.io/hostname"

--- a/ansible/12-configuracoes-cluster/templates/flannel-helm-config.yml.j2
+++ b/ansible/12-configuracoes-cluster/templates/flannel-helm-config.yml.j2
@@ -1,0 +1,14 @@
+# Range de IPs dos Pods
+podCidr: "{{ rede_cidr_pods }}"
+
+# Backend de rede
+backend: "vxlan"
+
+# Recursos mínimos para estabilidade
+resources:
+  requests:
+    cpu: "100m"
+    memory: "64Mi"
+  limits:
+    cpu: "500m"
+    memory: "256Mi"

--- a/docs/PROGRESSO.md
+++ b/docs/PROGRESSO.md
@@ -51,10 +51,10 @@
 - [x] Configuração do kube-proxy
 
 ### 🌐 Rede do Cluster
-- [ ] Escolha do CNI Plugin
-  - [ ] Instalação do plugin escolhido
-  - [ ] Configuração da rede dos pods
-  - [ ] Configuração da rede dos serviços
+- [x] Escolha do CNI Plugin
+  - [x] Instalação do plugin escolhido
+  - [x] Configuração da rede dos pods
+  - [x] Configuração da rede dos serviços
 - [ ] Instalação do CoreDNS
 - [ ] Configuração do MetalLB
 - [ ] Validação da rede

--- a/inventario/hosts.yml
+++ b/inventario/hosts.yml
@@ -61,3 +61,4 @@ all:
           fqdn: kubox.k8sbox.local
           memory: 512
           cpus: 1
+          autostart: false


### PR DESCRIPTION
Esse PR traz melhorias na criação e gestão do cluster. Foram aprimorados os playbooks Ansible, o controle de VMs no Vagrant e as tarefas do Makefile, tornando a configuração mais modular e idempotente.

Também foi adicionada a instalação via Helm do Flannel e do CoreDNS, com templates configuráveis, além de correções no `etcdctl` e ajustes nas atualizações e *taints* dos nós. As mudanças tornam o provisionamento mais previsível e padronizado.
