### PR TITLE
Otimização do Download de Imagens do Sistema e Extração Local do etcdctl

### DIFF
--- a/ansible/05-cluster-base/defaults/main.yml
+++ b/ansible/05-cluster-base/defaults/main.yml
@@ -11,6 +11,7 @@ pacotes_kubernetes:
   - socat
   - tar
   - xz
+  - skopeo
 
 modulos_kernel_kubernetes:
   - overlay

--- a/ansible/06-kubelet/tasks/06-configuracao-containerd.yml
+++ b/ansible/06-kubelet/tasks/06-configuracao-containerd.yml
@@ -13,7 +13,7 @@
         containerd_config.stdout
         | regex_replace('SystemdCgroup = false', 'SystemdCgroup = true')
         | regex_replace('sandbox_image = "registry.k8s.io/pause:[0-9.]+"',
-                        'sandbox_image = "registry.k8s.io/%s"' % versao_pause)
+                        'sandbox_image = "%s"' % node_images.pause)
       }}
     mode: "0644"
 

--- a/ansible/06-kubelet/tasks/06-configuracao-crio.yml
+++ b/ansible/06-kubelet/tasks/06-configuracao-crio.yml
@@ -11,7 +11,7 @@
       conmon = "/usr/libexec/crio/conmon"
 
       [crio.image]
-      pause_image = "registry.k8s.io/{{ versao_pause }}"
+      pause_image = "{{ node_images.pause }}"
 
       [crio.network]
       network_dir = "/etc/cni/net.d/"

--- a/ansible/06-kubelet/tasks/07-download-imagens-sistema.yml
+++ b/ansible/06-kubelet/tasks/07-download-imagens-sistema.yml
@@ -1,28 +1,123 @@
 # ansible/06-kubelet/tasks/07-download-imagens-sistema.yml
 ---
-- name: Definir lista de imagens para os managers
+- name: Garantir que a pasta temporária de imagens existe no Host
+  ansible.builtin.file:
+    path: "{{ pasta_temporarios }}/imagens"
+    state: directory
+    mode: "0755"
+  delegate_to: localhost
+  become: false
+  run_once: true
+
+- name: Verificar no Host se as imagens em formato Tarball já existem
+  ansible.builtin.stat:
+    path: "{{ pasta_temporarios }}/imagens/{{ item.key }}-{{ item.value | split(':') | last }}.tar"
+  register: imagens_tar_stat
+  delegate_to: localhost
+  become: false
+  run_once: true
+  loop: "{{ (node_images | combine(control_plane_images)) | dict2items }}"
+  loop_control:
+    label: "{{ item.value }}"
+
+- name: Baixar imagem usando skopeo no manager1 se ausente no Host
+  ansible.builtin.command: >
+    skopeo copy
+    docker://{{ item.item.value }}
+    docker-archive:/tmp/{{ item.item.key }}-{{ item.item.value | split(':') | last }}.tar:{{ item.item.value }}
+  delegate_to: "{{ groups['managers'][0] }}"
+  run_once: true
+  loop: "{{ imagens_tar_stat.results }}"
+  loop_control:
+    label: "{{ item.item.value }}"
+  when: not item.stat.exists
+  changed_when: true
+
+- name: Copiar tarball do manager1 de volta para a pasta de temporários no Host
+  ansible.builtin.fetch:
+    src: "/tmp/{{ item.item.key }}-{{ item.item.value | split(':') | last }}.tar"
+    dest: "{{ pasta_temporarios }}/imagens/{{ item.item.key }}-{{ item.item.value | split(':') | last }}.tar"
+    flat: true
+  delegate_to: "{{ groups['managers'][0] }}"
+  run_once: true
+  loop: "{{ imagens_tar_stat.results }}"
+  loop_control:
+    label: "{{ item.item.value }}"
+  when: not item.stat.exists
+
+- name: Remover tarball temporário da pasta /tmp do manager1
+  ansible.builtin.file:
+    path: "/tmp/{{ item.item.key }}-{{ item.item.value | split(':') | last }}.tar"
+    state: absent
+  delegate_to: "{{ groups['managers'][0] }}"
+  run_once: true
+  loop: "{{ imagens_tar_stat.results }}"
+  loop_control:
+    label: "{{ item.item.value }}"
+  when: not item.stat.exists
+
+# --- Fim da fase de download. Agora cada nó carrega suas respectivas imagens ---
+
+- name: Definir lista de imagens a carregar (para managers)
   ansible.builtin.set_fact:
-    imagens_kubernetes: "{{ node_images.values() | list + control_plane_images.values() | list }}"
+    imagens_kubernetes: "{{ (node_images | combine(control_plane_images)) | dict2items }}"
   when:
     - inventory_hostname in groups['managers']
 
-- name: Definir lista de imagens para os workers
+- name: Definir lista de imagens a carregar (para workers)
   ansible.builtin.set_fact:
-    imagens_kubernetes: "{{ node_images.values() | list }}"
+    imagens_kubernetes: "{{ node_images | dict2items }}"
   when: imagens_kubernetes is not defined
 
-- name: Verificar se as imagens do Kubernetes já existem localmente
+- name: Verificar se as imagens do Kubernetes já existem localmente no runtime
   ansible.builtin.command:
-    cmd: "/usr/local/bin/crictl images -q {{ item }}"
+    cmd: "/usr/local/bin/crictl images -q {{ item.value }}"
   register: crictl_image_check
   changed_when: false
   loop: "{{ imagens_kubernetes }}"
+  loop_control:
+    label: "{{ item.value }}"
 
-- name: Baixar imagens do Kubernetes ausentes
-  ansible.builtin.command:
-    cmd: "/usr/local/bin/crictl pull {{ item.item }}"
-  when: item.stdout == ""
+- name: Copiar tarball da imagem do Host para a VM
+  ansible.builtin.copy:
+    src: "{{ pasta_temporarios }}/imagens/{{ item.item.key }}-{{ item.item.value | split(':') | last }}.tar"
+    dest: "/tmp/{{ item.item.key }}.tar"
+    mode: "0644"
   loop: "{{ crictl_image_check.results }}"
   loop_control:
-    label: "{{ item.item }}"
+    label: "{{ item.item.value }}"
+  when: item.stdout == ""
+
+- name: Importar imagem no CRI-O usando skopeo
+  ansible.builtin.command: >
+    skopeo copy
+    docker-archive:/tmp/{{ item.item.key }}.tar
+    containers-storage:{{ item.item.value }}
+  loop: "{{ crictl_image_check.results }}"
+  loop_control:
+    label: "{{ item.item.value }}"
+  when:
+    - container_runtime == "crio"
+    - item.stdout == ""
   changed_when: true
+
+- name: Importar imagem no Containerd usando ctr
+  ansible.builtin.command: >
+    ctr -n k8s.io images import /tmp/{{ item.item.key }}.tar
+  loop: "{{ crictl_image_check.results }}"
+  loop_control:
+    label: "{{ item.item.value }}"
+  when:
+    - container_runtime == "containerd"
+    - item.stdout == ""
+  changed_when: true
+
+- name: Remover tarball temporário da pasta /tmp da VM
+  ansible.builtin.file:
+    path: "/tmp/{{ item.item.key }}.tar"
+    state: absent
+  loop: "{{ crictl_image_check.results }}"
+  loop_control:
+    label: "{{ item.item.value }}"
+  when: item.stdout == ""
+

--- a/ansible/12-ferramentas-cluster/tasks/01-instalacao.yml
+++ b/ansible/12-ferramentas-cluster/tasks/01-instalacao.yml
@@ -7,53 +7,6 @@
     mode: "0755"
   become: true
 
-- name: Verificar se o executável do etcdctl já está instalado na VM
-  ansible.builtin.stat:
-    path: "/usr/local/bin/etcdctl"
-  register: etcdctl_bin
-
-- name: Instalar o etcdctl se não existir
-  when: not etcdctl_bin.stat.exists
-  block:
-    - name: Garantir que a pasta de destino do etcdctl existe
-      ansible.builtin.file:
-        path: /tmp/etcdctl
-        state: directory
-        mode: "0755"
-
-    - name: Copiar etcdctl para a VM (em /tmp)
-      ansible.builtin.copy:
-        src: "{{ pasta_temporarios }}/etcd-bin.tar.gz"
-        dest: "/tmp/etcd-bin.tar.gz"
-        mode: "0644"
-
-    - name: Descompactar etcdctl
-      ansible.builtin.unarchive:
-        src: "/tmp/etcd-bin.tar.gz"
-        dest: "/tmp/etcdctl"
-        remote_src: true
-        mode: "0755"
-
-    - name: Instalar binário do etcdctl em /usr/local/bin
-      ansible.builtin.copy:
-        src: "/tmp/etcdctl/etcd-{{ versao_etcd }}-linux-amd64/{{ item }}"
-        dest: "/usr/local/bin/{{ item }}"
-        mode: "0755"
-        remote_src: true
-      become: true
-      loop:
-        - etcdctl
-
-  always:
-    - name: Remover diretório temporário do etcdctl
-      ansible.builtin.file:
-        path: "/tmp/etcdctl"
-        state: absent
-
-    - name: Remover arquivo temporário do etcdctl
-      ansible.builtin.file:
-        path: "/tmp/etcd-bin.tar.gz"
-        state: absent
 
 - name: Verificar se o executável do kubectl já está instalado na VM
   ansible.builtin.stat:

--- a/ansible/12-ferramentas-cluster/tasks/04-etcdctl.yml
+++ b/ansible/12-ferramentas-cluster/tasks/04-etcdctl.yml
@@ -1,0 +1,48 @@
+# ansible/12-ferramentas-cluster/tasks/04-etcdctl.yml
+---
+# O `kubectl cp` usa `tar` dentro do container para empacotar o arquivo antes
+# de transferi-lo. A imagem distroless do etcd não possui `tar`, tornando esse
+# método inviável. A alternativa é ler o mount point do overlay do container
+# diretamente via `crictl inspect`, que expõe o caminho do merged layer do
+# overlayfs. Esse caminho existe enquanto o container estiver rodando e é
+# independente do container runtime (containerd ou cri-o).
+- name: Verificar se o executável do etcdctl já está instalado na VM
+  ansible.builtin.stat:
+    path: "/usr/local/bin/etcdctl"
+  register: etcdctl_bin
+
+- name: Extrair etcdctl do overlay filesystem do container etcd no manager
+  when: not etcdctl_bin.stat.exists
+  block:
+    - name: Obter container ID do etcd em execução no manager principal
+      ansible.builtin.command: >
+        /usr/local/bin/crictl ps --name "^etcd$" --state Running -q
+      register: etcd_container_id
+      changed_when: false
+      delegate_to: "{{ groups['managers'][0] }}"
+      become: true
+
+    - name: Obter caminho do overlay filesystem do container etcd
+      ansible.builtin.shell: >
+        /usr/local/bin/crictl inspect {{ etcd_container_id.stdout | trim }} |
+        python3 -c "import json,sys; d=json.load(sys.stdin);
+        print(d['info']['runtimeSpec']['root']['path'])"
+      register: etcd_overlay_path
+      changed_when: false
+      delegate_to: "{{ groups['managers'][0] }}"
+      become: true
+
+    - name: Baixar etcdctl do overlay do manager para o host de controle
+      ansible.builtin.fetch:
+        src: "{{ etcd_overlay_path.stdout | trim }}/usr/local/bin/etcdctl"
+        dest: "{{ pasta_temporarios }}/etcdctl"
+        flat: true
+      delegate_to: "{{ groups['managers'][0] }}"
+      become: true
+
+    - name: Instalar etcdctl no kubox
+      ansible.builtin.copy:
+        src: "{{ pasta_temporarios }}/etcdctl"
+        dest: "/usr/local/bin/etcdctl"
+        mode: "0755"
+      become: true

--- a/ansible/12-ferramentas-cluster/tasks/main.yml
+++ b/ansible/12-ferramentas-cluster/tasks/main.yml
@@ -8,3 +8,6 @@
 
 - name: Configuração das ferramentas
   ansible.builtin.import_tasks: 03-configuracao.yml
+
+- name: Extrair etcdctl do cluster
+  ansible.builtin.import_tasks: 04-etcdctl.yml

--- a/inventario/group_vars/all.yml
+++ b/inventario/group_vars/all.yml
@@ -55,7 +55,7 @@ porta_kube_scheduler: 10259
 versao_etcd: "v3.6.8"         # https://endoflife.date/etcd e tag da versão corrente em https://github.com/kubernetes/kubernetes/blob/master/build/dependencies.yaml
 versao_kubernetes: "v1.36.1"  # https://endoflife.date/kubernetes e https://dl.k8s.io/release/stable.txt
 versao_crictl: "v1.36.0"      # https://github.com/kubernetes-sigs/cri-tools/releases
-versao_pause: "pause:3.10.2"  # https://github.com/kubernetes/kubernetes/blob/master/build/pause/CHANGELOG.md
+versao_pause: "3.10.2"        # https://github.com/kubernetes/kubernetes/blob/master/build/pause/CHANGELOG.md
 versao_cni: "v1.9.1"          # https://github.com/containernetworking/plugins/releases e https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
 versao_gateway_api: "v1.5.1"  # https://github.com/kubernetes-sigs/gateway-api/releases/
 versao_helm: "v3.21.0"        # https://github.com/helm/helm/releases
@@ -63,13 +63,14 @@ versao_k9s: "v0.50.18"        # https://github.com/derailed/k9s/releases
 versao_popeye: "v0.22.1"      # https://github.com/derailed/popeye/releases
 
 # Imagens necessárias em todos os nós do cluster (managers e workers)
+# Checar tags das imagens disponíveis em https://explore.ggcr.dev/?repo=registry.k8s.io
 node_images:
-  pause: "registry.k8s.io/{{ versao_pause }}"
+  pause: "registry.k8s.io/pause:{{ versao_pause }}"
   proxy: "registry.k8s.io/kube-proxy:{{ versao_kubernetes }}"
 
 # Imagens dos componentes do control plane (apenas managers)
 control_plane_images:
-  etcd: "registry.k8s.io/{{ versao_etcd }}"
+  etcd: "registry.k8s.io/etcd:{{ versao_etcd }}"
   apiserver: "registry.k8s.io/kube-apiserver:{{ versao_kubernetes }}"
   controller_manager: "registry.k8s.io/kube-controller-manager:{{ versao_kubernetes }}"
   scheduler: "registry.k8s.io/kube-scheduler:{{ versao_kubernetes }}"

--- a/inventario/group_vars/all.yml
+++ b/inventario/group_vars/all.yml
@@ -70,10 +70,10 @@ node_images:
 
 # Imagens dos componentes do control plane (apenas managers)
 control_plane_images:
-  etcd: "registry.k8s.io/etcd:{{ versao_etcd }}"
-  apiserver: "registry.k8s.io/kube-apiserver:{{ versao_kubernetes }}"
+  etcd:               "registry.k8s.io/etcd:{{ versao_etcd }}"
+  apiserver:          "registry.k8s.io/kube-apiserver:{{ versao_kubernetes }}"
   controller_manager: "registry.k8s.io/kube-controller-manager:{{ versao_kubernetes }}"
-  scheduler: "registry.k8s.io/kube-scheduler:{{ versao_kubernetes }}"
+  scheduler:          "registry.k8s.io/kube-scheduler:{{ versao_kubernetes }}"
 
 # Versões dos plugins de rede (CNI)
 versao_canal: "v3.32.0"       # https://github.com/projectcalico/calico/releases (Flannel + Calico)

--- a/inventario/group_vars/all.yml
+++ b/inventario/group_vars/all.yml
@@ -52,7 +52,7 @@ porta_kube_scheduler: 10259
 # - Kubernetes: https://kubernetes.io/releases/download/#binaries
 
 # Versões dos componentes
-versao_etcd: "v3.6.11"        # https://endoflife.date/etcd e 
+versao_etcd: "v3.6.8"         # https://endoflife.date/etcd e tag da versão corrente em https://github.com/kubernetes/kubernetes/blob/master/build/dependencies.yaml
 versao_kubernetes: "v1.36.1"  # https://endoflife.date/kubernetes e https://dl.k8s.io/release/stable.txt
 versao_crictl: "v1.36.0"      # https://github.com/kubernetes-sigs/cri-tools/releases
 versao_pause: "pause:3.10.2"  # https://github.com/kubernetes/kubernetes/blob/master/build/pause/CHANGELOG.md
@@ -67,9 +67,9 @@ node_images:
   pause: "registry.k8s.io/{{ versao_pause }}"
   proxy: "registry.k8s.io/kube-proxy:{{ versao_kubernetes }}"
 
-# Imagens dos componentes do control plane (apenas managers, modo pod)
+# Imagens dos componentes do control plane (apenas managers)
 control_plane_images:
-  etcd: "registry.k8s.io/etcd:3.5.16-0"
+  etcd: "registry.k8s.io/{{ versao_etcd }}"
   apiserver: "registry.k8s.io/kube-apiserver:{{ versao_kubernetes }}"
   controller_manager: "registry.k8s.io/kube-controller-manager:{{ versao_kubernetes }}"
   scheduler: "registry.k8s.io/kube-scheduler:{{ versao_kubernetes }}"
@@ -87,10 +87,6 @@ download_artefatos:
   yq-bin:
     url: "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64"
     arquivo: "yq"
-
-  etcd-bin:
-    url: "https://github.com/etcd-io/etcd/releases/download/{{ versao_etcd }}/etcd-{{ versao_etcd }}-linux-amd64.tar.gz"
-    arquivo: "etcd-bin.tar.gz"
 
   kubelet-bin:
     url: "https://dl.k8s.io/release/{{ versao_kubernetes }}/bin/linux/amd64/kubelet"


### PR DESCRIPTION
Este PR introduz melhorias de performance e confiabilidade na inicialização e provisionamento do cluster, focando em duas áreas principais:
1. **Cache local de imagens de containers no host de desenvolvimento:** Evita downloads repetidos da internet a cada execução limpa do playbook.
2. **Extração dinâmica do etcdctl:** Remove a necessidade de baixar o tarball completo do Etcd da internet, extraindo o binário etcdctl diretamente do overlay filesystem do container do Etcd em execução.

## Alterações Introduzidas

### 1. Otimização e Cache de Imagens de Sistema
* **Instalação do skopeo:** Adicionado como dependência de pacote base no Kubernetes (ansible/05-cluster-base/defaults/main.yml).
* **Fluxo de Download e Distribuição (ansible/06-kubelet/tasks/07-download-imagens-sistema.yml):**
  1. O host local (localhost) verifica se já possui os tarballs das imagens necessárias em cache (imagens/).
  2. Se não existirem, o manager1 faz o download via skopeo copy direto para um tarball local e transfere (fetch) de volta para o host de desenvolvimento.
  3. Para cada nó do cluster (Manager/Worker), se o container runtime (crio ou containerd) não possuir a imagem carregada, o tarball é enviado do host e importado localmente:
     * **CRI-O:** Importação usando skopeo copy.
     * **Containerd:** Importação usando ctr -n k8s.io images import.
  4. Isso economiza banda e tempo de deploy ao reutilizar imagens já baixadas.

### 2. Remoção do Download Binário do Etcd
* **Extração do etcdctl via OverlayFS (ansible/12-ferramentas-cluster/tasks/04-etcdctl.yml):**
  * Removido o download direto do binário do etcd em download_artefatos (inventario/group_vars/all.yml).
  * Agora, o script busca o container do etcd em execução via crictl, encontra o seu diretório raiz correspondente no overlayfs usando crictl inspect + parse JSON com Python, copia o binário etcdctl já existente no container para o host de controle e depois o instala no Kubox.

### 3. Ajustes de Variáveis e Nomenclaturas
* Correção na definição da versão da imagem pause (versao_pause definida apenas como a tag 3.10.2 ao invés de pause:3.10.2).
* Alinhamento da tag da imagem do etcd no control plane para usar a variável versao_etcd atualizada (v3.6.8).
* Atualização dos templates de configuração do crio e containerd para apontar diretamente para a chave corrigida node_images.pause.