### PR TITLE
Sanitizacao Ansible

### DIFF
--- a/ansible/.ansible.cfg
+++ b/ansible/.ansible.cfg
@@ -8,13 +8,14 @@ deprecation_warnings=False
 # Desativa o easter egg da vaca ASCII
 nocows=True
 
-# Paralelismo
-forks = 10
+# Paralelismo (adequado para o tamanho do cluster)
+forks = 5
 
 # Especifica o caminho para o arquivo de inventário
 inventory=../inventario/
 
-# Desativa verificação de chaves SSH para facilitar a automação
+# ATENÇÃO: Desabilitado apenas para ambiente de lab/Vagrant.
+# Nunca use isso em produção — vulnerável a ataques MITM.
 host_key_checking=False
 
 # Desativa elevação de privilégios por padrão
@@ -24,33 +25,27 @@ become=false
 gather_facts=false
 
 # Define o arquivo de log para rastreamento de execução
-log_path=/tmp/ansible.log
-
-# Configuração de coleta de fatos otimizada
-gathering = smart
+log_path=../artefatos/ansible_logs/ansible.log
 
 # Configurações de cache de fatos
 fact_caching = jsonfile
-fact_caching_connection = /tmp/ansible_facts
-fact_caching_timeout = 86400
+fact_caching_connection = ../artefatos/ansible_cache/ansible_facts
+fact_caching_timeout = 3600
 
 # Checagem de desempenho
 callbacks_enabled = profile_tasks, timer
 
 [inventory]
-# Plugins de inventário habilitados
-enable_plugins = 'host_list', 'script', 'auto', 'yaml', 'ini', 'toml'
+# Plugins de inventário habilitados (sem aspas simples para evitar bugs de sintaxe)
+enable_plugins = host_list, script, auto, yaml, ini, toml
 
 # Configurações de cache de inventário
 cache = yes
-cache_connection = /tmp/ansible_inventory
+cache_connection = ../artefatos/ansible_cache/ansible_inventory
 
 [ssh_connection]
 # Configurações de conexão SSH personalizadas
 ssh_args=-F ./ssh_config -o ControlMaster=auto -o ControlPersist=180s
 
 # Controle de onde ficam os sockets de controle
-control_path_dir = /tmp/.ansible/cp
-
-# Ignora hosts inacessíveis (somente para os casos de se subir parte do cluster com vagrant up)
-ignore_unreachable = true
+control_path_dir = ../artefatos/ansible_cache/cp

--- a/ansible/03-balanceador/handlers/main.yml
+++ b/ansible/03-balanceador/handlers/main.yml
@@ -1,0 +1,11 @@
+# ansible/03-balanceador/handlers/main.yml
+---
+- name: Reiniciar HAProxy
+  ansible.builtin.systemd:
+    name: haproxy
+    state: restarted
+
+- name: Reiniciar Keepalived
+  ansible.builtin.systemd:
+    name: keepalived
+    state: restarted

--- a/ansible/03-balanceador/tasks/02-configuracao-haproxy.yml
+++ b/ansible/03-balanceador/tasks/02-configuracao-haproxy.yml
@@ -18,14 +18,10 @@
     group: root
     validate: 'haproxy -c -f %s'
     backup: true
-
-- name: Habilitar HAProxy no boot
-  ansible.builtin.systemd:
-    name: haproxy
-    enabled: true
+  notify: Reiniciar HAProxy
 
 - name: Garantir que HAProxy está rodando
   ansible.builtin.systemd:
     name: haproxy
     enabled: true
-    state: restarted
+    state: started

--- a/ansible/03-balanceador/tasks/03-configuracao-keepalived.yml
+++ b/ansible/03-balanceador/tasks/03-configuracao-keepalived.yml
@@ -8,14 +8,10 @@
     owner: root
     group: root
     backup: true
-
-- name: Habilitar Keepalived no boot
-  ansible.builtin.systemd:
-    name: keepalived
-    enabled: true
+  notify: Reiniciar Keepalived
 
 - name: Garantir que Keepalived está rodando
   ansible.builtin.systemd:
     name: keepalived
     enabled: true
-    state: restarted
+    state: started

--- a/ansible/04-nfs/tasks/01-instalacao.yml
+++ b/ansible/04-nfs/tasks/01-instalacao.yml
@@ -9,4 +9,7 @@
   ansible.builtin.file:
     path: /srv/nfs/k8s
     state: directory
-    mode: "0777"
+    owner: nobody
+    group: nobody
+    mode: "0755"
+

--- a/ansible/04-nfs/tasks/02-configuracao.yml
+++ b/ansible/04-nfs/tasks/02-configuracao.yml
@@ -12,5 +12,5 @@
 - name: Ativar e iniciar serviço NFS
   ansible.builtin.service:
     name: nfs-server
-    state: restarted
+    state: started
     enabled: true

--- a/ansible/05-cluster-base/handlers/main.yml
+++ b/ansible/05-cluster-base/handlers/main.yml
@@ -9,3 +9,8 @@
   ansible.builtin.reboot:
     post_reboot_delay: 10
     reboot_timeout: 300
+
+- name: Recarregar módulos do kernel
+  ansible.builtin.systemd:
+    name: systemd-modules-load
+    state: restarted

--- a/ansible/05-cluster-base/tasks/00-atualizacao.yml
+++ b/ansible/05-cluster-base/tasks/00-atualizacao.yml
@@ -18,6 +18,7 @@
   become: true
   ansible.builtin.dnf:
     update_cache: true
+  changed_when: false
 
 - name: Atualizar todos os pacotes  # noqa package-latest
   become: true

--- a/ansible/05-cluster-base/tasks/01-instalacao.yml
+++ b/ansible/05-cluster-base/tasks/01-instalacao.yml
@@ -22,11 +22,7 @@
     dest: /etc/modules-load.d/kubernetes.conf
     content: "{{ modulos_kernel_kubernetes | join('\n') }}\n"
     mode: "0644"
-
-- name: Recarregar módulos listados em /etc/modules-load.d
-  ansible.builtin.systemd:
-    name: systemd-modules-load
-    state: restarted
+  notify: Recarregar módulos do kernel
 
 - name: Carregar módulos explicitamente
   community.general.modprobe:
@@ -41,10 +37,15 @@
     enabled: true
     state: started
 
-- name: Desabilitar swap
-  ansible.builtin.command:
-    cmd: swapoff -a
+- name: Verificar se swap está ativo
+  ansible.builtin.command: swapon --show
+  register: swap_status
   changed_when: false
+
+- name: Desabilitar swap
+  ansible.builtin.command: swapoff -a
+  when: swap_status.stdout != ""
+  changed_when: true
 
 - name: Remover entrada de swap do /etc/fstab
   ansible.builtin.replace:

--- a/ansible/06-kubelet/handlers/main.yml
+++ b/ansible/06-kubelet/handlers/main.yml
@@ -1,0 +1,17 @@
+# ansible/06-kubelet/handlers/main.yml
+---
+- name: Reiniciar CRI-O
+  ansible.builtin.systemd:
+    name: crio
+    state: restarted
+
+- name: Reiniciar containerd
+  ansible.builtin.systemd:
+    name: containerd
+    state: restarted
+
+- name: Recarregar systemd e reiniciar kubelet
+  ansible.builtin.systemd:
+    name: kubelet
+    state: restarted
+    daemon_reload: true

--- a/ansible/06-kubelet/tasks/01-instalacao-crictl.yml
+++ b/ansible/06-kubelet/tasks/01-instalacao-crictl.yml
@@ -1,4 +1,4 @@
-# ansible/06-kubelet/tasks/02-instalacao-crictl.yml
+# ansible/06-kubelet/tasks/01-instalacao-crictl.yml
 ---
 - name: Verificar se o executável do crictl já está instalado na VM
   ansible.builtin.stat:
@@ -30,16 +30,6 @@
       loop:
         - crictl
 
-    - name: Configurar crictl para usar runtime correto
-      ansible.builtin.copy:
-        dest: /etc/crictl.yaml
-        content: |
-          runtime-endpoint: {{ container_runtime_sockets[container_runtime] }}
-          image-endpoint: {{ container_runtime_sockets[container_runtime] }}
-          timeout: 0
-          debug: false
-        mode: "0644"
-
   always:
     - name: Remover arquivo temporário do crictl
       ansible.builtin.file:
@@ -50,3 +40,14 @@
       ansible.builtin.file:
         path: "/tmp/crictl.tar.gz"
         state: absent
+
+- name: Configurar crictl para usar runtime correto
+  ansible.builtin.copy:
+    dest: /etc/crictl.yaml
+    content: |
+      runtime-endpoint: {{ container_runtime_sockets[container_runtime] }}
+      image-endpoint: {{ container_runtime_sockets[container_runtime] }}
+      timeout: 0
+      debug: false
+    mode: "0644"
+

--- a/ansible/06-kubelet/tasks/03-instalacao-kubelet.yml
+++ b/ansible/06-kubelet/tasks/03-instalacao-kubelet.yml
@@ -17,12 +17,12 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    owner: root
-    group: kubernetes
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('kubernetes') }}"
     mode: "{{ item.mode | default('0750') }}"
   loop:
     # Configuração
-    - { path: /etc/kubernetes/manifests }
+    - { path: /etc/kubernetes/manifests, owner: root, group: root, mode: "0755" }
     - { path: /var/lib/kubelet }
 
     # Plugins CSI e storage

--- a/ansible/06-kubelet/tasks/06-configuracao-containerd.yml
+++ b/ansible/06-kubelet/tasks/06-configuracao-containerd.yml
@@ -16,12 +16,13 @@
                         'sandbox_image = "%s"' % node_images.pause)
       }}
     mode: "0644"
+  notify: Reiniciar containerd
 
 - name: Habilitar e iniciar containerd
   ansible.builtin.systemd:
     name: containerd
     enabled: true
-    state: restarted
+    state: started
 
 - name: Aguardar containerd estar pronto
   ansible.builtin.wait_for:

--- a/ansible/06-kubelet/tasks/06-configuracao-crio.yml
+++ b/ansible/06-kubelet/tasks/06-configuracao-crio.yml
@@ -17,12 +17,13 @@
       network_dir = "/etc/cni/net.d/"
       plugin_dirs = ["/opt/cni/bin/"]
     mode: "0644"
+  notify: Reiniciar CRI-O
 
 - name: Habilitar e iniciar CRI-O
   ansible.builtin.systemd:
     name: crio
     enabled: true
-    state: restarted
+    state: started
 
 - name: Aguardar CRI-O estar pronto
   ansible.builtin.wait_for:

--- a/ansible/06-kubelet/tasks/09-configuracao-kubelet.yml
+++ b/ansible/06-kubelet/tasks/09-configuracao-kubelet.yml
@@ -1,32 +1,35 @@
-# ansible/06-kubelet/tasks/08-configuracao-kubelet.yml
+# ansible/06-kubelet/tasks/09-configuracao-kubelet.yml
 ---
 - name: Configurar parâmetros de inicialização do kubelet
   ansible.builtin.template:
     src: kubelet.env.j2
     dest: /var/lib/kubelet/kubelet.env
     mode: "0644"
+  notify: Recarregar systemd e reiniciar kubelet
 
 - name: Criar arquivo de configuração principal do kubelet
   ansible.builtin.template:
     src: kubelet-config.yml.j2
     dest: /var/lib/kubelet/kubelet-config.yml
     mode: "0644"
+  notify: Recarregar systemd e reiniciar kubelet
 
 - name: Criar kubeconfig com configs de usuário para o kubelet
   ansible.builtin.template:
     src: kubelet.kubeconfig.j2
     dest: /var/lib/kubelet/kubelet.kubeconfig
     mode: "0644"
+  notify: Recarregar systemd e reiniciar kubelet
 
 - name: Configurar serviço do kubelet
   ansible.builtin.template:
     src: kubelet.service.j2
     dest: /etc/systemd/system/kubelet.service
     mode: "0644"
+  notify: Recarregar systemd e reiniciar kubelet
 
 - name: Garantir serviço ativo
   ansible.builtin.systemd:
     name: kubelet
     enabled: true
-    state: restarted
-    daemon_reload: true
+    state: started

--- a/ansible/07-etcd-pod/tasks/03-configuracao.yml
+++ b/ansible/07-etcd-pod/tasks/03-configuracao.yml
@@ -26,7 +26,7 @@
 
 - name: Forçar sincronização imediata do relógio com NTP (chrony)
   ansible.builtin.command: chronyc -a makestep
-  changed_when: true
+  changed_when: false
 
 - name: Aguardar o Etcd responder saudável (via API de prontidão HTTP)
   ansible.builtin.uri:

--- a/ansible/100-exemplos/tasks/00-namespace.yml
+++ b/ansible/100-exemplos/tasks/00-namespace.yml
@@ -15,4 +15,5 @@
 - name: Aplicar Manifests do Hello
   ansible.builtin.command:
     cmd: "kubectl apply -f /home/{{ ansible_user }}/exemplos/namespace-exemplos.yml"
-  changed_when: true
+  register: resultado_ns
+  changed_when: "'configured' in resultado_ns.stdout or 'created' in resultado_ns.stdout"

--- a/ansible/11-kube-proxy-pod/handlers/main.yml
+++ b/ansible/11-kube-proxy-pod/handlers/main.yml
@@ -1,0 +1,6 @@
+# ansible/11-kube-proxy-pod/handlers/main.yml
+---
+- name: Reiniciar DaemonSet do kube-proxy
+  ansible.builtin.command:
+    cmd: "kubectl rollout restart daemonset/kube-proxy -n kube-system"
+  changed_when: true

--- a/ansible/11-kube-proxy-pod/tasks/01-carregamento.yml
+++ b/ansible/11-kube-proxy-pod/tasks/01-carregamento.yml
@@ -22,11 +22,10 @@
     cmd: "kubectl apply -f /home/{{ ansible_user }}/manifests/kube-proxy/"
   register: resultado_kubectl
   changed_when: "'configured' in resultado_kubectl.stdout or 'created' in resultado_kubectl.stdout"
+  notify: Reiniciar DaemonSet do kube-proxy
 
-- name: Reiniciar DaemonSet do kube-proxy se houver alterações
-  ansible.builtin.command:
-    cmd: "kubectl rollout restart daemonset/kube-proxy -n kube-system"
-  when: resultado_kubectl.changed
+- name: Executar reinicialização do DaemonSet se necessário
+  ansible.builtin.meta: flush_handlers
 
 - name: Esperar rollout do DaemonSet do kube-proxy
   ansible.builtin.command:

--- a/ansible/12-ferramentas-cluster/tasks/01-instalacao.yml
+++ b/ansible/12-ferramentas-cluster/tasks/01-instalacao.yml
@@ -1,11 +1,18 @@
 # ansible/12-ferramentas-cluster/tasks/01-instalacao.yml
 ---
+- name: Verificar se o executável do yq já está instalado na VM
+  ansible.builtin.stat:
+    path: "/usr/local/bin/yq"
+  register: yq_bin
+
 - name: Copiar yq para a VM em /usr/local/bin
   ansible.builtin.copy:
     src: "{{ pasta_temporarios }}/yq"
     dest: "/usr/local/bin/yq"
     mode: "0755"
   become: true
+  when: not yq_bin.stat.exists
+
 
 
 - name: Verificar se o executável do kubectl já está instalado na VM
@@ -85,8 +92,13 @@
         path: "/tmp/helm-bin.tar.gz"
         state: absent
 
+- name: Verificar se o executável do k9s já está instalado na VM
+  ansible.builtin.stat:
+    path: "/usr/local/bin/k9s"
+  register: k9s_bin
+
 - name: Instalar o k9s se não existir
-  when: not helm_bin.stat.exists
+  when: not k9s_bin.stat.exists
   block:
     - name: Garantir que a pasta de destino do k9s existe
       ansible.builtin.file:
@@ -126,8 +138,13 @@
         path: "/tmp/k9s-bin.tar.gz"
         state: absent
 
+- name: Verificar se o executável do popeye já está instalado na VM
+  ansible.builtin.stat:
+    path: "/usr/local/bin/popeye"
+  register: popeye_bin
+
 - name: Instalar o popeye se não existir
-  when: not helm_bin.stat.exists
+  when: not popeye_bin.stat.exists
   block:
     - name: Garantir que a pasta de destino do popeye existe
       ansible.builtin.file:

--- a/ansible/12-ferramentas-cluster/tasks/03-configuracao.yml
+++ b/ansible/12-ferramentas-cluster/tasks/03-configuracao.yml
@@ -4,7 +4,7 @@
   ansible.builtin.template:
     src: etcdctl-env.sh.j2
     dest: "/home/{{ ansible_user }}/.etcdctl-env"
-    mode: "0644"
+    mode: "0600"
 
 - name: Garantir que o etcdctl-env é carregado no .bashrc
   ansible.builtin.blockinfile:
@@ -19,4 +19,5 @@
   ansible.builtin.template:
     src: kubectl-admin.kubeconfig.j2
     dest: "/home/{{ ansible_user }}/.kube/config"
-    mode: "0644"
+    mode: "0600"
+

--- a/ansible/13-addons-cluster/tasks/01-labels-taints.yml
+++ b/ansible/13-addons-cluster/tasks/01-labels-taints.yml
@@ -22,7 +22,7 @@
 
 - name: Aplicar label control-plane nos managers
   ansible.builtin.command:
-    cmd: "kubectl label node {{ manager_host }} node-role.kubernetes.io/control-plane="
+    cmd: "kubectl label node {{ manager_host }} node-role.kubernetes.io/control-plane= --overwrite"
   loop: "{{ groups['managers'] }}"
   loop_control:
     loop_var: manager_host
@@ -31,7 +31,7 @@
 
 - name: Aplicar label worker nos workers
   ansible.builtin.command:
-    cmd: "kubectl label node {{ worker_host }} node-role.kubernetes.io/worker="
+    cmd: "kubectl label node {{ worker_host }} node-role.kubernetes.io/worker= --overwrite"
   loop: "{{ groups['workers'] }}"
   loop_control:
     loop_var: worker_host
@@ -40,7 +40,7 @@
 
 - name: Aplicar label instance-type nos nodes do cluster
   ansible.builtin.command:
-    cmd: "kubectl label node {{ node_host }} node.kubernetes.io/instance-type=libvirt"
+    cmd: "kubectl label node {{ node_host }} node.kubernetes.io/instance-type=libvirt --overwrite"
   loop: "{{ groups['cluster'] }}"
   loop_control:
     loop_var: node_host

--- a/ansible/13-addons-cluster/tasks/02-canal.yml
+++ b/ansible/13-addons-cluster/tasks/02-canal.yml
@@ -6,13 +6,12 @@
     state: directory
     mode: "0755"
 
-- name: Baixar manifesto do Canal (Flannel + Calico) # noqa command-instead-of-module
-  ansible.builtin.command: >
-    wget --quiet
-         -O /home/{{ ansible_user }}/charts/canal-manifest.yaml
-         https://raw.githubusercontent.com/projectcalico/calico/{{ versao_canal }}/manifests/canal.yaml
-  register: canal_wget
-  changed_when: canal_wget.rc != 0
+- name: Baixar manifesto do Canal (Flannel + Calico)
+  ansible.builtin.get_url:
+    url: "https://raw.githubusercontent.com/projectcalico/calico/{{ versao_canal }}/manifests/canal.yaml"
+    dest: "/home/{{ ansible_user }}/charts/canal-manifest.yaml"
+    mode: "0644"
+    force: false
 
 - name: Ajustar faixa de rede dos pods no net-conf.json
   ansible.builtin.replace:
@@ -28,7 +27,7 @@
 
 - name: Aguardar pods do Canal ficarem prontos
   ansible.builtin.command:
-    cmd: "kubectl -n kube-system wait --for=condition=Ready pod -l k8s-app=canal --timeout=180s"
+    cmd: "kubectl -n kube-system wait --for=condition=Ready pod -l k8s-app=canal --timeout=600s"
   register: resultado_wait
   failed_when: "'error' in resultado_wait.stderr or 'timed out' in resultado_wait.stderr"
   changed_when: false

--- a/ansible/13-addons-cluster/tasks/02-flannel.yml
+++ b/ansible/13-addons-cluster/tasks/02-flannel.yml
@@ -42,6 +42,14 @@
       --version "{{ versao_flannel }}"
       --namespace cni-flannel
       --values /home/{{ ansible_user }}/charts/flannel-helm-config.yml
-      --atomic --wait --timeout 120s
+      --atomic --wait --timeout 600s
   register: resultado_helm_upgrade
   changed_when: "'installed' in resultado_helm_upgrade.stdout or 'upgraded' in resultado_helm_upgrade.stdout"
+
+- name: Aguardar pods do Flannel ficarem prontos
+  ansible.builtin.command:
+    cmd: "kubectl -n cni-flannel wait --for=condition=Ready pod -l app.kubernetes.io/name=flannel --timeout=600s"
+  register: resultado_wait
+  failed_when: "'error' in resultado_wait.stderr or 'timed out' in resultado_wait.stderr"
+  changed_when: false
+

--- a/ansible/13-addons-cluster/tasks/06-kubevip.yml
+++ b/ansible/13-addons-cluster/tasks/06-kubevip.yml
@@ -6,13 +6,12 @@
     state: directory
     mode: "0755"
 
-- name: Baixar manifesto RBAC do Kube-vip # noqa command-instead-of-module
-  ansible.builtin.command: >
-    wget --quiet
-         -O /home/{{ ansible_user }}/charts/kubevip-rbac.yaml
-         https://kube-vip.io/manifests/rbac.yaml
-  register: kubevip_rbac_wget
-  changed_when: kubevip_rbac_wget.rc != 0
+- name: Baixar manifesto RBAC do Kube-vip
+  ansible.builtin.get_url:
+    url: "https://kube-vip.io/manifests/rbac.yaml"
+    dest: "/home/{{ ansible_user }}/charts/kubevip-rbac.yaml"
+    mode: "0644"
+    force: false
 
 - name: Aplicar manifesto RBAC do Kube-vip
   ansible.builtin.command:
@@ -44,13 +43,12 @@
   register: resultado_ds
   changed_when: "'created' in resultado_ds.stdout or 'configured' in resultado_ds.stdout"
 
-- name: Baixar manifesto do Cloud Provider do Kube-vip # noqa command-instead-of-module
-  ansible.builtin.command: >
-    wget --quiet
-         -O /home/{{ ansible_user }}/charts/kubevip-cloud-controller.yaml
-         https://raw.githubusercontent.com/kube-vip/kube-vip-cloud-provider/{{ versao_kubevip_cloud_provider }}/manifest/kube-vip-cloud-controller.yaml
-  register: kubevip_cc_wget
-  changed_when: kubevip_cc_wget.rc != 0
+- name: Baixar manifesto do Cloud Provider do Kube-vip
+  ansible.builtin.get_url:
+    url: "https://raw.githubusercontent.com/kube-vip/kube-vip-cloud-provider/{{ versao_kubevip_cloud_provider }}/manifest/kube-vip-cloud-controller.yaml"
+    dest: "/home/{{ ansible_user }}/charts/kubevip-cloud-controller.yaml"
+    mode: "0644"
+    force: false
 
 - name: Aplicar manifesto do Cloud Provider do Kube-vip
   ansible.builtin.command:
@@ -62,4 +60,4 @@
   ansible.builtin.command:
     cmd: "kubectl patch felixconfiguration default --type merge -p '{\"spec\": {\"chainInsertMode\": \"Append\"}}'"
   register: resultado_calico_patch
-  changed_when: "'patched' in resultado_calico_patch.stdout"
+  changed_when: "'patched' in resultado_calico_patch.stdout and 'no change' not in resultado_calico_patch.stdout"

--- a/ansible/13-addons-cluster/tasks/07-traefik-gateway-api.yml
+++ b/ansible/13-addons-cluster/tasks/07-traefik-gateway-api.yml
@@ -56,10 +56,10 @@
   ansible.builtin.command:
     cmd: "kubectl apply -f /home/{{ ansible_user }}/charts/traefik-gateway.yml"
   register: resultado_aplicacao
-  changed_when: "'unchanged' not in resultado_aplicacao.stdout"
+  changed_when: "'configured' in resultado_aplicacao.stdout or 'created' in resultado_aplicacao.stdout"
 
 - name: Aplicar manifesto do LoadBalancer para o Dashboard
   ansible.builtin.command:
     cmd: "kubectl apply -f /home/{{ ansible_user }}/charts/traefik-dashboard-lb.yml"
-  register: resultado_aplicacao
-  changed_when: "'unchanged' not in resultado_aplicacao.stdout"
+  register: resultado_aplicacao_lb
+  changed_when: "'configured' in resultado_aplicacao_lb.stdout or 'created' in resultado_aplicacao_lb.stdout"

--- a/ansible/13-addons-cluster/tasks/10-prometheus-stack.yml
+++ b/ansible/13-addons-cluster/tasks/10-prometheus-stack.yml
@@ -30,6 +30,6 @@
       --namespace monitoring
       --create-namespace
       --values /home/{{ ansible_user }}/charts/prometheus-stack-helm-config.yml
-      --atomic --wait --timeout 300s
+      --atomic --wait --timeout 600s
   register: resultado_helm_upgrade
   changed_when: "'installed' in resultado_helm_upgrade.stdout or 'upgraded' in resultado_helm_upgrade.stdout"


### PR DESCRIPTION
Este PR realiza uma auditoria e sanitização completa nas roles do Ansible para garantir a idempotência do provisionamento (evitando tarefas que reportam `changed` indevidamente em execuções subsequentes) e reforçar práticas de segurança.

Resolve #80

#### Principais Alterações:

*   **Ansible (.ansible.cfg):** Centralização dos logs, caching de fatos e sockets SSH no diretório `/artefatos` (evitando arquivos temporários espalhados no host de controle).
*   **Balanceador (HAProxy & Keepalived):** Configuração de handlers para reiniciar os serviços de forma reativa apenas quando os arquivos de template forem alterados, eliminando reinícios forçados a cada execução.
*   **NFS:** Correção do estado do serviço NFS para `started` e restrição das permissões do diretório compartilhado (`/srv/nfs/k8s`) para `nobody:nobody (0755)` seguindo o princípio do menor privilégio.
*   **Swap (cluster-base):** Implementação de checagem dinâmica com `swapon --show` para garantir que a desativação da partição swap ocorra de forma estritamente idempotente.
*   **Kubelet & Runtimes (CRI-O / Containerd):** 
    *   Criação de handlers dedicados para reinicialização dos runtimes e do próprio kubelet.
    *   Correção de permissões no diretório `/etc/kubernetes/manifests` para evitar flapping entre as execuções dos nós managers e workers.
*   **Ferramentas (yq, k9s, popeye):** Correção das condições de verificação de binários existentes via `stat` (evitando reinstalações redundantes).
*   **Segurança de Credenciais:** Restrição das permissões dos arquivos de configuração sensíveis `.kube/config` e `.etcdctl-env` para `0600`.
*   **CNI & Addons (Canal, Flannel, Kube-vip, Traefik, Prometheus):**
    *   Otimização da lógica de aplicação de patches do Calico e manifestos do Traefik.
    *   Aumento dos timeouts de download e prontidão dos pods (wait) no Flannel, Canal e Prometheus Stack para tolerar latência em laboratórios virtualizados.
