### PR TITLE
Checagem Validade PKI

### DIFF
--- a/ansible/01-pki/tasks/101-root-ca.yml
+++ b/ansible/01-pki/tasks/101-root-ca.yml
@@ -12,6 +12,26 @@
   register: ca_root_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do Root CA existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_root_ca.path_cert }}"
+  register: root_ca_info
+  when: ca_root_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se Root CA deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_root_ca: >-
+      {{
+        not ca_root_arquivos.results[0].stat.exists
+        or not ca_root_arquivos.results[1].stat.exists
+        or (root_ca_info.expired | default(false))
+        or (root_ca_info.not_after is defined and
+            ((root_ca_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do Root CA
   community.crypto.openssl_privatekey:
     path: "{{ pki_root_ca.path_chave }}"
@@ -19,7 +39,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not ca_root_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_root_ca
   delegate_to: localhost
 
 - name: Gerar CSR do Root CA
@@ -42,7 +62,7 @@
       - keyCertSign
       - cRLSign
     key_usage_critical: true
-  when: not ca_root_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_root_ca
   delegate_to: localhost
   register: ca_root_csr
 
@@ -56,5 +76,5 @@
     selfsigned_not_after: "+{{ pki_validade.root | default(1825) }}d"
     mode: "0644"
     force: true
-  when: not ca_root_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_root_ca
   delegate_to: localhost

--- a/ansible/01-pki/tasks/102-ca-etcd.yml
+++ b/ansible/01-pki/tasks/102-ca-etcd.yml
@@ -12,6 +12,36 @@
   register: ca_etcd_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do CA do Etcd existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_cas.etcd.path_cert }}"
+  register: ca_etcd_info
+  when: ca_etcd_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do Root CA vigente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_root_ca.path_cert }}"
+  register: root_ca_ski_info
+  when: ca_etcd_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se CA do Etcd deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_ca_etcd: >-
+      {{
+        not ca_etcd_arquivos.results[0].stat.exists
+        or not ca_etcd_arquivos.results[1].stat.exists
+        or (ca_etcd_info.expired | default(false))
+        or (ca_etcd_info.not_after is defined and
+            ((ca_etcd_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (ca_etcd_info.authority_key_identifier | default(none) is not none and
+            root_ca_ski_info.subject_key_identifier | default(none) is not none and
+            ca_etcd_info.authority_key_identifier != root_ca_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada da CA do Etcd
   community.crypto.openssl_privatekey:
     path: "{{ pki_cas.etcd.path_chave }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not ca_etcd_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_ca_etcd
   delegate_to: localhost
 
 - name: Gerar CSR da CA do Etcd
@@ -37,7 +67,7 @@
       - keyCertSign
       - cRLSign
     key_usage_critical: true
-  when: not ca_etcd_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_ca_etcd
   delegate_to: localhost
   register: ca_etcd_csr
 
@@ -52,5 +82,5 @@
     ownca_not_after: "+{{ pki_validade.intermediario | default(365) }}d"
     mode: "0644"
     force: true
-  when: not ca_etcd_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_ca_etcd
   delegate_to: localhost

--- a/ansible/01-pki/tasks/103-ca-kubernetes.yml
+++ b/ansible/01-pki/tasks/103-ca-kubernetes.yml
@@ -12,6 +12,36 @@
   register: ca_k8s_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do CA do Kubernetes existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_cas.kubernetes.path_cert }}"
+  register: ca_k8s_info
+  when: ca_k8s_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do Root CA vigente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_root_ca.path_cert }}"
+  register: root_ca_ski_info
+  when: ca_k8s_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se CA do Kubernetes deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_ca_kubernetes: >-
+      {{
+        not ca_k8s_arquivos.results[0].stat.exists
+        or not ca_k8s_arquivos.results[1].stat.exists
+        or (ca_k8s_info.expired | default(false))
+        or (ca_k8s_info.not_after is defined and
+            ((ca_k8s_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (ca_k8s_info.authority_key_identifier | default(none) is not none and
+            root_ca_ski_info.subject_key_identifier | default(none) is not none and
+            ca_k8s_info.authority_key_identifier != root_ca_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada da CA do Kubernetes
   community.crypto.openssl_privatekey:
     path: "{{ pki_cas.kubernetes.path_chave }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not ca_k8s_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_ca_kubernetes
   delegate_to: localhost
 
 - name: Gerar CSR da CA do Kubernetes
@@ -37,7 +67,7 @@
       - keyCertSign
       - cRLSign
     key_usage_critical: true
-  when: not ca_k8s_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_ca_kubernetes
   delegate_to: localhost
   register: ca_k8s_csr
 
@@ -52,5 +82,5 @@
     ownca_not_after: "+{{ pki_validade.intermediario | default(365) }}d"
     mode: "0644"
     force: true
-  when: not ca_k8s_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_ca_kubernetes
   delegate_to: localhost

--- a/ansible/01-pki/tasks/104-ca-front-proxy.yml
+++ b/ansible/01-pki/tasks/104-ca-front-proxy.yml
@@ -12,6 +12,36 @@
   register: ca_front_proxy_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do CA do Front Proxy existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_cas.front_proxy.path_cert }}"
+  register: ca_front_proxy_info
+  when: ca_front_proxy_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do Root CA vigente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_root_ca.path_cert }}"
+  register: root_ca_ski_info
+  when: ca_front_proxy_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se CA do Front Proxy deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_ca_front_proxy: >-
+      {{
+        not ca_front_proxy_arquivos.results[0].stat.exists
+        or not ca_front_proxy_arquivos.results[1].stat.exists
+        or (ca_front_proxy_info.expired | default(false))
+        or (ca_front_proxy_info.not_after is defined and
+            ((ca_front_proxy_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (ca_front_proxy_info.authority_key_identifier | default(none) is not none and
+            root_ca_ski_info.subject_key_identifier | default(none) is not none and
+            ca_front_proxy_info.authority_key_identifier != root_ca_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada da CA do Front Proxy
   community.crypto.openssl_privatekey:
     path: "{{ pki_cas.front_proxy.path_chave }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not ca_front_proxy_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_ca_front_proxy
   delegate_to: localhost
 
 - name: Gerar CSR da CA do Front Proxy
@@ -37,7 +67,7 @@
       - keyCertSign
       - cRLSign
     key_usage_critical: true
-  when: not ca_front_proxy_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_ca_front_proxy
   delegate_to: localhost
   register: ca_front_proxy_csr
 
@@ -52,5 +82,5 @@
     ownca_not_after: "+{{ pki_validade.intermediario | default(365) }}d"
     mode: "0644"
     force: true
-  when: not ca_front_proxy_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_ca_front_proxy
   delegate_to: localhost

--- a/ansible/01-pki/tasks/201-cert-etcd-server.yml
+++ b/ansible/01-pki/tasks/201-cert-etcd-server.yml
@@ -12,6 +12,36 @@
   register: etcd_server_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado de servidor Etcd existente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.etcd_server.path_cert | format(manager_host) }}"
+  register: etcd_server_info
+  when: etcd_server_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Etcd vigente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.etcd_server.ca_pai.path_cert }}"
+  register: ca_etcd_ski_info
+  when: etcd_server_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado de servidor Etcd deve ser gerado ({{ manager_host }})
+  ansible.builtin.set_fact:
+    pki_deve_gerar_etcd_server: >-
+      {{
+        not etcd_server_arquivos.results[0].stat.exists
+        or not etcd_server_arquivos.results[1].stat.exists
+        or (etcd_server_info.expired | default(false))
+        or (etcd_server_info.not_after is defined and
+            ((etcd_server_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (etcd_server_info.authority_key_identifier | default(none) is not none and
+            ca_etcd_ski_info.subject_key_identifier | default(none) is not none and
+            etcd_server_info.authority_key_identifier != ca_etcd_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para cliente mTLS do servidor Etcd ({{ manager_host }})
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.etcd_server.path_chave | format(manager_host) }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not etcd_server_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_etcd_server
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para cliente mTLS do servidor Etcd ({{ manager_host }})
@@ -40,7 +70,7 @@
       - clientAuth
     extended_key_usage_critical: true
     subject_alt_name: "{{ lookup('template', '201-san-etcd-server.j2') | from_yaml }}"
-  when: not etcd_server_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_etcd_server
   delegate_to: localhost
   register: etcd_server_csr
 
@@ -55,5 +85,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not etcd_server_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_etcd_server
   delegate_to: localhost

--- a/ansible/01-pki/tasks/202-cert-etcd-peer.yml
+++ b/ansible/01-pki/tasks/202-cert-etcd-peer.yml
@@ -12,6 +12,36 @@
   register: etcd_peer_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado de peer Etcd existente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.etcd_peer.path_cert | format(manager_host) }}"
+  register: etcd_peer_info
+  when: etcd_peer_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Etcd vigente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.etcd_peer.ca_pai.path_cert }}"
+  register: ca_etcd_ski_info
+  when: etcd_peer_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado de peer Etcd deve ser gerado ({{ manager_host }})
+  ansible.builtin.set_fact:
+    pki_deve_gerar_etcd_peer: >-
+      {{
+        not etcd_peer_arquivos.results[0].stat.exists
+        or not etcd_peer_arquivos.results[1].stat.exists
+        or (etcd_peer_info.expired | default(false))
+        or (etcd_peer_info.not_after is defined and
+            ((etcd_peer_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (etcd_peer_info.authority_key_identifier | default(none) is not none and
+            ca_etcd_ski_info.subject_key_identifier | default(none) is not none and
+            etcd_peer_info.authority_key_identifier != ca_etcd_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para cliente mTLS do peer Etcd ({{ manager_host }})
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.etcd_peer.path_chave | format(manager_host) }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not etcd_peer_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_etcd_peer
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para cliente mTLS do peer Etcd ({{ manager_host }})
@@ -40,7 +70,7 @@
       - clientAuth
     extended_key_usage_critical: true
     subject_alt_name: "{{ lookup('template', '202-san-etcd-peer.j2') | from_yaml }}"
-  when: not etcd_peer_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_etcd_peer
   delegate_to: localhost
   register: etcd_peer_csr
 
@@ -55,5 +85,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not etcd_peer_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_etcd_peer
   delegate_to: localhost

--- a/ansible/01-pki/tasks/203-cert-etcd-cli.yml
+++ b/ansible/01-pki/tasks/203-cert-etcd-cli.yml
@@ -1,6 +1,6 @@
 # ansible/01-pki/tasks/203-cert-etcd-cli.yml
 ---
-- name: Verificar arquivos existentes da chave para o Cliente Etcd
+- name: Verificar arquivos existentes da chave para o cliente Etcd / Etcdctl
   ansible.builtin.stat:
     path: "{{ arquivo }}"
   loop:
@@ -12,22 +12,52 @@
   register: etcd_cli_arquivos
   delegate_to: localhost
 
-- name: Criar chave privada do certificado para o Cliente Etcd
+- name: Verificar informações do certificado de cliente Etcd existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.etcd_cli.path_cert }}"
+  register: etcd_cli_info
+  when: etcd_cli_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Etcd vigente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.etcd_cli.ca_pai.path_cert }}"
+  register: ca_etcd_ski_info
+  when: etcd_cli_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado de cliente Etcd deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_etcd_cli: >-
+      {{
+        not etcd_cli_arquivos.results[0].stat.exists
+        or not etcd_cli_arquivos.results[1].stat.exists
+        or (etcd_cli_info.expired | default(false))
+        or (etcd_cli_info.not_after is defined and
+            ((etcd_cli_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (etcd_cli_info.authority_key_identifier | default(none) is not none and
+            ca_etcd_ski_info.subject_key_identifier | default(none) is not none and
+            etcd_cli_info.authority_key_identifier != ca_etcd_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
+- name: Criar chave privada do certificado para o cliente Etcd
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.etcd_cli.path_chave }}"
     type: "{{ pki_cifra_tipo }}"
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not etcd_cli_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_etcd_cli
   delegate_to: localhost
 
-- name: Gerar CSR do certificado para o Cliente Etcd
+- name: Gerar CSR do certificado para o cliente Etcd
   community.crypto.openssl_csr_pipe:
     privatekey_path: "{{ pki_certs.etcd_cli.path_chave }}"
     digest: "{{ pki_algoritmo_hash }}"
     subject:
-      CN: etcdctl
+      CN: etcd-client
     use_common_name_for_san: false
     basic_constraints:
       - "CA:FALSE"
@@ -39,11 +69,11 @@
       - clientAuth
     extended_key_usage_critical: true
     subject_alt_name: "{{ lookup('template', '203-san-etcd-cli.j2') | from_yaml }}"
-  when: not etcd_cli_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_etcd_cli
   delegate_to: localhost
   register: etcd_cli_csr
 
-- name: Assinar certificado para o Cliente Etcd com o respectivo CA intermediário
+- name: Assinar certificado de cliente Etcd com o respectivo CA intermediário
   community.crypto.x509_certificate:
     path: "{{ pki_certs.etcd_cli.path_cert }}"
     csr_content: "{{ etcd_cli_csr.csr }}"
@@ -54,5 +84,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not etcd_cli_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_etcd_cli
   delegate_to: localhost

--- a/ansible/01-pki/tasks/211-cert-kube-apiserver.yml
+++ b/ansible/01-pki/tasks/211-cert-kube-apiserver.yml
@@ -12,6 +12,36 @@
   register: kube_apiserver_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado do kube-apiserver existente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_apiserver.path_cert | format(manager_host) }}"
+  register: kube_apiserver_info
+  when: kube_apiserver_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Kubernetes vigente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_apiserver.ca_pai.path_cert }}"
+  register: ca_k8s_ski_info
+  when: kube_apiserver_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado do kube-apiserver deve ser gerado ({{ manager_host }})
+  ansible.builtin.set_fact:
+    pki_deve_gerar_kube_apiserver: >-
+      {{
+        not kube_apiserver_arquivos.results[0].stat.exists
+        or not kube_apiserver_arquivos.results[1].stat.exists
+        or (kube_apiserver_info.expired | default(false))
+        or (kube_apiserver_info.not_after is defined and
+            ((kube_apiserver_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (kube_apiserver_info.authority_key_identifier | default(none) is not none and
+            ca_k8s_ski_info.subject_key_identifier | default(none) is not none and
+            kube_apiserver_info.authority_key_identifier != ca_k8s_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para o kube-apiserver ({{ manager_host }})
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.kube_apiserver.path_chave | format(manager_host) }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not kube_apiserver_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_apiserver
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para o kube-apiserver ({{ manager_host }})
@@ -39,7 +69,7 @@
       - serverAuth
     extended_key_usage_critical: true
     subject_alt_name: "{{ lookup('template', '211-san-kube-apiserver.j2') | from_yaml }}"
-  when: not kube_apiserver_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_apiserver
   delegate_to: localhost
   register: kube_apiserver_csr
 
@@ -54,5 +84,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not kube_apiserver_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_apiserver
   delegate_to: localhost

--- a/ansible/01-pki/tasks/212-cert-kube-apiserver-etcd-cli.yml
+++ b/ansible/01-pki/tasks/212-cert-kube-apiserver-etcd-cli.yml
@@ -12,6 +12,36 @@
   register: kube_apiserver_etcd_cli_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado cliente apiserver→etcd existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_apiserver_etcd_cli.path_cert }}"
+  register: kube_apiserver_etcd_cli_info
+  when: kube_apiserver_etcd_cli_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Etcd vigente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_apiserver_etcd_cli.ca_pai.path_cert }}"
+  register: ca_etcd_ski_info
+  when: kube_apiserver_etcd_cli_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado cliente apiserver→etcd deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_kube_apiserver_etcd_cli: >-
+      {{
+        not kube_apiserver_etcd_cli_arquivos.results[0].stat.exists
+        or not kube_apiserver_etcd_cli_arquivos.results[1].stat.exists
+        or (kube_apiserver_etcd_cli_info.expired | default(false))
+        or (kube_apiserver_etcd_cli_info.not_after is defined and
+            ((kube_apiserver_etcd_cli_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (kube_apiserver_etcd_cli_info.authority_key_identifier | default(none) is not none and
+            ca_etcd_ski_info.subject_key_identifier | default(none) is not none and
+            kube_apiserver_etcd_cli_info.authority_key_identifier != ca_etcd_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para cliente do kube-apiserver para Etcd
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.kube_apiserver_etcd_cli.path_chave }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not kube_apiserver_etcd_cli_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_apiserver_etcd_cli
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para cliente do kube-apiserver para Etcd
@@ -39,7 +69,7 @@
       - clientAuth
     extended_key_usage_critical: true
     subject_alt_name: "{{ lookup('template', '212-san-kube-apiserver-etcd-cli.j2') | from_yaml }}"
-  when: not kube_apiserver_etcd_cli_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_apiserver_etcd_cli
   delegate_to: localhost
   register: etcd_apiserver_cli_csr
 
@@ -54,5 +84,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not kube_apiserver_etcd_cli_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_apiserver_etcd_cli
   delegate_to: localhost

--- a/ansible/01-pki/tasks/213-cert-kube-apiserver-kubelet-cli.yml
+++ b/ansible/01-pki/tasks/213-cert-kube-apiserver-kubelet-cli.yml
@@ -12,6 +12,36 @@
   register: kube_apiserver_kubelet_cli_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado cliente apiserver→kubelet existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_apiserver_kubelet_cli.path_cert }}"
+  register: kube_apiserver_kubelet_cli_info
+  when: kube_apiserver_kubelet_cli_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Kubernetes vigente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_apiserver_kubelet_cli.ca_pai.path_cert }}"
+  register: ca_k8s_ski_info
+  when: kube_apiserver_kubelet_cli_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado cliente apiserver→kubelet deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_kube_apiserver_kubelet_cli: >-
+      {{
+        not kube_apiserver_kubelet_cli_arquivos.results[0].stat.exists
+        or not kube_apiserver_kubelet_cli_arquivos.results[1].stat.exists
+        or (kube_apiserver_kubelet_cli_info.expired | default(false))
+        or (kube_apiserver_kubelet_cli_info.not_after is defined and
+            ((kube_apiserver_kubelet_cli_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (kube_apiserver_kubelet_cli_info.authority_key_identifier | default(none) is not none and
+            ca_k8s_ski_info.subject_key_identifier | default(none) is not none and
+            kube_apiserver_kubelet_cli_info.authority_key_identifier != ca_k8s_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para cliente do kube-apiserver para Kubelet
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.kube_apiserver_kubelet_cli.path_chave }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not kube_apiserver_kubelet_cli_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_apiserver_kubelet_cli
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para cliente do kube-apiserver para Kubelet
@@ -40,7 +70,7 @@
       - clientAuth
     extended_key_usage_critical: true
     subject_alt_name: "{{ lookup('template', '213-san-kube-apiserver-kubelet-cli.j2') | from_yaml }}"
-  when: not kube_apiserver_kubelet_cli_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_apiserver_kubelet_cli
   delegate_to: localhost
   register: kube_apiserver_kubelet_cli_csr
 
@@ -55,5 +85,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not kube_apiserver_kubelet_cli_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_apiserver_kubelet_cli
   delegate_to: localhost

--- a/ansible/01-pki/tasks/214-cert-kube-controller-manager.yml
+++ b/ansible/01-pki/tasks/214-cert-kube-controller-manager.yml
@@ -12,6 +12,36 @@
   register: kube_controller_manager_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado do kube-controller-manager existente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_controller_manager.path_cert | format(manager_host) }}"
+  register: kube_controller_manager_info
+  when: kube_controller_manager_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Kubernetes vigente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_controller_manager.ca_pai.path_cert }}"
+  register: ca_k8s_ski_info
+  when: kube_controller_manager_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado do kube-controller-manager deve ser gerado ({{ manager_host }})
+  ansible.builtin.set_fact:
+    pki_deve_gerar_kube_controller_manager: >-
+      {{
+        not kube_controller_manager_arquivos.results[0].stat.exists
+        or not kube_controller_manager_arquivos.results[1].stat.exists
+        or (kube_controller_manager_info.expired | default(false))
+        or (kube_controller_manager_info.not_after is defined and
+            ((kube_controller_manager_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (kube_controller_manager_info.authority_key_identifier | default(none) is not none and
+            ca_k8s_ski_info.subject_key_identifier | default(none) is not none and
+            kube_controller_manager_info.authority_key_identifier != ca_k8s_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para o kube-controller-manager ({{ manager_host }})
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.kube_controller_manager.path_chave | format(manager_host) }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not kube_controller_manager_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_controller_manager
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para o kube-controller-manager ({{ manager_host }})
@@ -39,7 +69,7 @@
       - clientAuth
     extended_key_usage_critical: true
     subject_alt_name: "{{ lookup('template', '214-san-kube-controller-manager.j2') | from_yaml }}"
-  when: not kube_controller_manager_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_controller_manager
   delegate_to: localhost
   register: kube_controller_manager_csr
 
@@ -54,5 +84,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not kube_controller_manager_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_controller_manager
   delegate_to: localhost

--- a/ansible/01-pki/tasks/215-cert-kube-scheduler.yml
+++ b/ansible/01-pki/tasks/215-cert-kube-scheduler.yml
@@ -12,6 +12,36 @@
   register: kube_scheduler_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado do kube-scheduler existente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_scheduler.path_cert | format(manager_host) }}"
+  register: kube_scheduler_info
+  when: kube_scheduler_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Kubernetes vigente ({{ manager_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_scheduler.ca_pai.path_cert }}"
+  register: ca_k8s_ski_info
+  when: kube_scheduler_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado do kube-scheduler deve ser gerado ({{ manager_host }})
+  ansible.builtin.set_fact:
+    pki_deve_gerar_kube_scheduler: >-
+      {{
+        not kube_scheduler_arquivos.results[0].stat.exists
+        or not kube_scheduler_arquivos.results[1].stat.exists
+        or (kube_scheduler_info.expired | default(false))
+        or (kube_scheduler_info.not_after is defined and
+            ((kube_scheduler_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (kube_scheduler_info.authority_key_identifier | default(none) is not none and
+            ca_k8s_ski_info.subject_key_identifier | default(none) is not none and
+            kube_scheduler_info.authority_key_identifier != ca_k8s_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para o kube-scheduler ({{ manager_host }})
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.kube_scheduler.path_chave | format(manager_host) }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not kube_scheduler_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_scheduler
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para o kube-scheduler ({{ manager_host }})
@@ -39,7 +69,7 @@
       - clientAuth
     extended_key_usage_critical: true
     subject_alt_name: "{{ lookup('template', '215-san-kube-scheduler.j2') | from_yaml }}"
-  when: not kube_scheduler_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_scheduler
   delegate_to: localhost
   register: kube_scheduler_csr
 
@@ -54,5 +84,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not kube_scheduler_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_scheduler
   delegate_to: localhost

--- a/ansible/01-pki/tasks/221-cert-kubelet.yml
+++ b/ansible/01-pki/tasks/221-cert-kubelet.yml
@@ -12,6 +12,36 @@
   register: kubelet_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado do kubelet existente ({{ node_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kubelet.path_cert | format(node_host) }}"
+  register: kubelet_info
+  when: kubelet_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Kubernetes vigente ({{ node_host }})
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kubelet.ca_pai.path_cert }}"
+  register: ca_k8s_ski_info
+  when: kubelet_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado do kubelet deve ser gerado ({{ node_host }})
+  ansible.builtin.set_fact:
+    pki_deve_gerar_kubelet: >-
+      {{
+        not kubelet_arquivos.results[0].stat.exists
+        or not kubelet_arquivos.results[1].stat.exists
+        or (kubelet_info.expired | default(false))
+        or (kubelet_info.not_after is defined and
+            ((kubelet_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (kubelet_info.authority_key_identifier | default(none) is not none and
+            ca_k8s_ski_info.subject_key_identifier | default(none) is not none and
+            kubelet_info.authority_key_identifier != ca_k8s_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para o kubelet ({{ node_host }})
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.kubelet.path_chave | format(node_host) }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not kubelet_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kubelet
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para o kubelet ({{ node_host }})
@@ -41,7 +71,7 @@
       - serverAuth
     extended_key_usage_critical: true
     subject_alt_name: "{{ lookup('template', '221-san-kubelet.j2') | from_yaml }}"
-  when: not kubelet_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kubelet
   delegate_to: localhost
   register: kubelet_csr
 
@@ -56,5 +86,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not kubelet_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kubelet
   delegate_to: localhost

--- a/ansible/01-pki/tasks/223-cert-service-account.yml
+++ b/ansible/01-pki/tasks/223-cert-service-account.yml
@@ -12,6 +12,36 @@
   register: service_account_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado de Service Account existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.service_account.path_cert }}"
+  register: service_account_info
+  when: service_account_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Kubernetes vigente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.service_account.ca_pai.path_cert }}"
+  register: ca_k8s_ski_info
+  when: service_account_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado de Service Account deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_service_account: >-
+      {{
+        not service_account_arquivos.results[0].stat.exists
+        or not service_account_arquivos.results[1].stat.exists
+        or (service_account_info.expired | default(false))
+        or (service_account_info.not_after is defined and
+            ((service_account_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (service_account_info.authority_key_identifier | default(none) is not none and
+            ca_k8s_ski_info.subject_key_identifier | default(none) is not none and
+            service_account_info.authority_key_identifier != ca_k8s_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para o Service Account
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.service_account.path_chave }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not service_account_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_service_account
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para o Service Account
@@ -32,7 +62,7 @@
     basic_constraints:
       - "CA:FALSE"
     basic_constraints_critical: true
-  when: not service_account_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_service_account
   delegate_to: localhost
   register: service_account_csr
 
@@ -47,5 +77,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not service_account_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_service_account
   delegate_to: localhost

--- a/ansible/01-pki/tasks/224-cert-admin-account.yml
+++ b/ansible/01-pki/tasks/224-cert-admin-account.yml
@@ -12,6 +12,36 @@
   register: admin_account_arquivos
   delegate_to: localhost
 
+- name: Verificar informações do certificado de Admin Account existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.admin_account.path_cert }}"
+  register: admin_account_info
+  when: admin_account_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Kubernetes vigente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.admin_account.ca_pai.path_cert }}"
+  register: ca_k8s_ski_info
+  when: admin_account_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado de Admin Account deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_admin_account: >-
+      {{
+        not admin_account_arquivos.results[0].stat.exists
+        or not admin_account_arquivos.results[1].stat.exists
+        or (admin_account_info.expired | default(false))
+        or (admin_account_info.not_after is defined and
+            ((admin_account_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (admin_account_info.authority_key_identifier | default(none) is not none and
+            ca_k8s_ski_info.subject_key_identifier | default(none) is not none and
+            admin_account_info.authority_key_identifier != ca_k8s_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
 - name: Criar chave privada do certificado para o Admin Account
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.admin_account.path_chave }}"
@@ -19,7 +49,7 @@
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not admin_account_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_admin_account
   delegate_to: localhost
 
 - name: Gerar CSR do certificado para o Admin Account
@@ -39,7 +69,7 @@
     extended_key_usage:
       - clientAuth
     extended_key_usage_critical: true
-  when: not admin_account_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_admin_account
   delegate_to: localhost
   register: admin_account_csr
 
@@ -54,5 +84,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not admin_account_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_admin_account
   delegate_to: localhost

--- a/ansible/01-pki/tasks/231-cert-front-proxy-cli.yml
+++ b/ansible/01-pki/tasks/231-cert-front-proxy-cli.yml
@@ -1,6 +1,6 @@
 # ansible/01-pki/tasks/231-cert-front-proxy-cli.yml
 ---
-- name: Verificar arquivos existentes da chave para certificado do Kube Proxy
+- name: Verificar arquivos existentes da chave para certificado do Front Proxy Client
   ansible.builtin.stat:
     path: "{{ arquivo }}"
   loop:
@@ -12,17 +12,47 @@
   register: kube_front_proxy_cli_arquivos
   delegate_to: localhost
 
-- name: Criar chave privada do certificado para certificado do Kube Proxy
+- name: Verificar informações do certificado de Front Proxy Client existente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_front_proxy_cli.path_cert }}"
+  register: kube_front_proxy_cli_info
+  when: kube_front_proxy_cli_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Verificar SKI do CA do Front Proxy vigente
+  community.crypto.x509_certificate_info:
+    path: "{{ pki_certs.kube_front_proxy_cli.ca_pai.path_cert }}"
+  register: ca_front_proxy_ski_info
+  when: kube_front_proxy_cli_arquivos.results[1].stat.exists
+  delegate_to: localhost
+
+- name: Decidir se certificado de Front Proxy Client deve ser gerado
+  ansible.builtin.set_fact:
+    pki_deve_gerar_kube_front_proxy_cli: >-
+      {{
+        not kube_front_proxy_cli_arquivos.results[0].stat.exists
+        or not kube_front_proxy_cli_arquivos.results[1].stat.exists
+        or (kube_front_proxy_cli_info.expired | default(false))
+        or (kube_front_proxy_cli_info.not_after is defined and
+            ((kube_front_proxy_cli_info.not_after | to_datetime('%Y%m%d%H%M%SZ')) - now()).days
+            < pki_validade.alerta | int)
+        or (kube_front_proxy_cli_info.authority_key_identifier | default(none) is not none and
+            ca_front_proxy_ski_info.subject_key_identifier | default(none) is not none and
+            kube_front_proxy_cli_info.authority_key_identifier != ca_front_proxy_ski_info.subject_key_identifier)
+      }}
+  delegate_to: localhost
+
+- name: Criar chave privada do certificado para certificado do Front Proxy Client
   community.crypto.openssl_privatekey:
     path: "{{ pki_certs.kube_front_proxy_cli.path_chave }}"
     type: "{{ pki_cifra_tipo }}"
     curve: "{{ pki_cifra_algo }}"
     state: "present"
     force: true
-  when: not kube_front_proxy_cli_arquivos.results[0].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_front_proxy_cli
   delegate_to: localhost
 
-- name: Gerar CSR do certificado para certificado do Kube Proxy
+- name: Gerar CSR do certificado para certificado do Front Proxy Client
   community.crypto.openssl_csr_pipe:
     privatekey_path: "{{ pki_certs.kube_front_proxy_cli.path_chave }}"
     digest: "{{ pki_algoritmo_hash }}"
@@ -38,11 +68,11 @@
     extended_key_usage:
       - clientAuth
     extended_key_usage_critical: true
-  when: not kube_front_proxy_cli_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_front_proxy_cli
   delegate_to: localhost
   register: kube_front_proxy_cli_csr
 
-- name: Assinar certificado para certificado do Kube Proxy com o respectivo CA intermediário
+- name: Assinar certificado para certificado do Front Proxy Client com o respectivo CA intermediário
   community.crypto.x509_certificate:
     path: "{{ pki_certs.kube_front_proxy_cli.path_cert }}"
     csr_content: "{{ kube_front_proxy_cli_csr.csr }}"
@@ -53,5 +83,5 @@
     ownca_not_after: "+{{ pki_validade.certificado | default(30) }}d"
     mode: "0644"
     force: true
-  when: not kube_front_proxy_cli_arquivos.results[1].stat.exists or (pki_regerar_certs | default(false) | bool)
+  when: pki_deve_gerar_kube_front_proxy_cli
   delegate_to: localhost

--- a/ansible/06-kubelet/tasks/05-pki.yml
+++ b/ansible/06-kubelet/tasks/05-pki.yml
@@ -29,3 +29,5 @@
       mode: "0640"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Recarregar systemd e reiniciar kubelet
+

--- a/ansible/07-etcd-pod/handlers/main.yml
+++ b/ansible/07-etcd-pod/handlers/main.yml
@@ -1,0 +1,10 @@
+# ansible/07-etcd-pod/handlers/main.yml
+---
+- name: Reiniciar Static Pod do Etcd
+  ansible.builtin.file:
+    path: /etc/kubernetes/manifests/etcd.yaml
+    state: touch
+    modification_time: now
+    owner: root
+    group: root
+    mode: "0644"

--- a/ansible/07-etcd-pod/tasks/02-pki.yml
+++ b/ansible/07-etcd-pod/tasks/02-pki.yml
@@ -20,6 +20,7 @@
     owner: root
     group: root
     mode: "0644"
+  notify: Reiniciar Static Pod do Etcd
 
 # Certificados do servidor (específico do nó)
 - name: Copiar certificados do servidor
@@ -36,6 +37,7 @@
       dest: "/etc/kubernetes/conf/etcd/pki/server/{{ pki_certs.etcd_server.path_chave | format(inventory_hostname) | basename }}"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do Etcd
 
 # Certificados peer (todos os certificados para comunicação mútua)
 - name: Copiar certificados peer do nó atual
@@ -52,3 +54,4 @@
       dest: "/etc/kubernetes/conf/etcd/pki/peer/{{ pki_certs.etcd_peer.path_chave | format(inventory_hostname) | basename }}"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do Etcd

--- a/ansible/08-kube-apiserver-pod/handlers/main.yml
+++ b/ansible/08-kube-apiserver-pod/handlers/main.yml
@@ -1,0 +1,10 @@
+# ansible/08-kube-apiserver-pod/handlers/main.yml
+---
+- name: Reiniciar Static Pod do kube-apiserver
+  ansible.builtin.file:
+    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+    state: touch
+    modification_time: now
+    owner: root
+    group: root
+    mode: "0644"

--- a/ansible/08-kube-apiserver-pod/tasks/02-pki.yml
+++ b/ansible/08-kube-apiserver-pod/tasks/02-pki.yml
@@ -23,6 +23,7 @@
     owner: root
     group: root
     mode: "0644"
+  notify: Reiniciar Static Pod do kube-apiserver
 
 # CA do Etcd (--etcd-cafile)
 - name: Copiar CA do Etcd
@@ -32,6 +33,7 @@
     owner: root
     group: root
     mode: "0644"
+  notify: Reiniciar Static Pod do kube-apiserver
 
 # CA do Front Proxy (--requestheader-client-ca-file)
 - name: Copiar CA do Front Proxy
@@ -41,6 +43,7 @@
     owner: root
     group: root
     mode: "0644"
+  notify: Reiniciar Static Pod do kube-apiserver
 
 # Certificado cliente apiserver→etcd (--etcd-certfile / --etcd-keyfile)
 - name: Copiar certificados cliente apiserver→etcd
@@ -59,6 +62,7 @@
       mode: "0640"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-apiserver
 
 # Certificado cliente apiserver→kubelet (--kubelet-client-certificate / --kubelet-client-key)
 - name: Copiar certificados cliente apiserver→kubelet
@@ -77,6 +81,7 @@
       mode: "0640"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-apiserver
 
 # Certificado cliente front-proxy (--proxy-client-cert-file / --proxy-client-key-file)
 - name: Copiar certificados cliente front-proxy
@@ -95,6 +100,7 @@
       mode: "0640"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-apiserver
 
 # Chaves de Service Account (--service-account-key-file / --service-account-signing-key-file)
 - name: Copiar chaves de Service Account
@@ -113,6 +119,7 @@
       mode: "0640"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-apiserver
 
 # TLS do servidor (--tls-cert-file / --tls-private-key-file) — específico por nó
 - name: Copiar certificado TLS do kube-apiserver (específico do nó)
@@ -131,3 +138,4 @@
       mode: "0640"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-apiserver

--- a/ansible/09-kube-controller-manager-pod/handlers/main.yml
+++ b/ansible/09-kube-controller-manager-pod/handlers/main.yml
@@ -1,0 +1,10 @@
+# ansible/09-kube-controller-manager-pod/handlers/main.yml
+---
+- name: Reiniciar Static Pod do kube-controller-manager
+  ansible.builtin.file:
+    path: /etc/kubernetes/manifests/kube-controller-manager.yaml
+    state: touch
+    modification_time: now
+    owner: root
+    group: root
+    mode: "0644"

--- a/ansible/09-kube-controller-manager-pod/tasks/02-pki.yml
+++ b/ansible/09-kube-controller-manager-pod/tasks/02-pki.yml
@@ -32,6 +32,7 @@
       mode: "0644"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-controller-manager
 
 - name: Copiar certificados de Service Account
   ansible.builtin.copy:
@@ -49,6 +50,7 @@
       mode: "0640"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-controller-manager
 
 - name: Copiar certificados do kube-controller-manager (específico do nó)
   ansible.builtin.copy:
@@ -70,3 +72,4 @@
       mode: "0640"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-controller-manager

--- a/ansible/10-kube-scheduler-pod/handlers/main.yml
+++ b/ansible/10-kube-scheduler-pod/handlers/main.yml
@@ -1,0 +1,10 @@
+# ansible/10-kube-scheduler-pod/handlers/main.yml
+---
+- name: Reiniciar Static Pod do kube-scheduler
+  ansible.builtin.file:
+    path: /etc/kubernetes/manifests/kube-scheduler.yaml
+    state: touch
+    modification_time: now
+    owner: root
+    group: root
+    mode: "0644"

--- a/ansible/10-kube-scheduler-pod/tasks/02-pki.yml
+++ b/ansible/10-kube-scheduler-pod/tasks/02-pki.yml
@@ -24,6 +24,7 @@
       mode: "0644"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-scheduler
 
 - name: Copiar certificados do kube-scheduler (específico do nó)
   ansible.builtin.copy:
@@ -41,3 +42,4 @@
       mode: "0640"
   loop_control:
     label: "{{ item.dest }}"
+  notify: Reiniciar Static Pod do kube-scheduler

--- a/ansible/cluster.yml
+++ b/ansible/cluster.yml
@@ -67,6 +67,7 @@
   hosts: cluster
   become: true
   gather_facts: false
+  serial: 1
   roles:
     - role: 06-kubelet
       tags:


### PR DESCRIPTION
Este pull request implementa uma automação robusta para o ciclo de vida do PKI do cluster, substituindo as verificações simples de existência de arquivo por validações criptográficas de integridade e expiração (via `x509_certificate_info`). Isso garante que certificados expirados ou com divergências de AKI/SKI sejam regenerados de forma automática e em cascata.

Além disso, foram adicionados handlers dedicados para reiniciar o Kubelet e os Static Pods (Etcd, API Server, Controller Manager e Scheduler) após atualizações de chaves, garantindo a aplicação segura e imediata dos novos certificados sob execução serializada para evitar indisponibilidade no cluster.

Resolve #79